### PR TITLE
Add HotelEvents test skeleton, WindingTreeEconomy test helper

### DIFF
--- a/test/BookingData.js
+++ b/test/BookingData.js
@@ -16,14 +16,10 @@ const web3 = new Web3(provider);
   : HotelManager = require('../libs/HotelManager.js');
 
 describe('BookingData', function() {
-  const defaultGas = 400000;
-
   let Manager;
   let token;
   let index;
   let accounts;
-  let fundingSource;
-  let daoAccount;
   let ownerAccount;
   let augusto;
   let jakub;
@@ -31,53 +27,16 @@ describe('BookingData', function() {
   let unitAddress;
 
   before(async function(){
-    const wallet = await web3.eth.accounts.wallet.create(4);
     accounts = await web3.eth.getAccounts();
+    ({
+      index,
+      token,
+      wallet
+    } = await help.createWindingTreeEconomy(accounts, web3));
 
-    fundingSource = accounts[0];
-    ownerAccount = wallet["0"].address;
-    daoAccount = wallet["1"].address;
+    ownerAccount = wallet["1"].address;
     augusto = wallet["2"].address;
     jakub = wallet["3"].address;
-
-    await util.fundAccount(fundingSource, ownerAccount, 50, web3);
-    await util.fundAccount(fundingSource, daoAccount, 50, web3);
-    await util.fundAccount(fundingSource, augusto, 50, web3);
-    await util.fundAccount(fundingSource, jakub, 50, web3);
-
-    index = await util.deployIndex({
-      owner: daoAccount,
-      gasMargin: 1.5,
-      web3: web3
-    });
-
-    token = await help.runTokenGenerationEvent();
-
-    const setLifData = await index.methods
-      .setLifToken(token.options.address)
-      .encodeABI();
-
-    const setLifOptions = {
-      from: daoAccount,
-      to: index.options.address,
-      gas: defaultGas,
-      data: setLifData
-    };
-
-    await web3.eth.sendTransaction(setLifOptions);
-
-    tokenFundingOptions = {
-      token: token,
-      sender: fundingSource,
-      value: 500,
-      web3: web3
-    };
-
-    tokenFundingOptions.receiver = augusto;
-    await help.sendTokens(tokenFundingOptions);
-
-    tokenFundingOptions.receiver = jakub;
-    await help.sendTokens(tokenFundingOptions);
   })
 
   beforeEach( async function() {

--- a/test/HotelEvents.js
+++ b/test/HotelEvents.js
@@ -1,0 +1,98 @@
+const User = require('../libs/User');
+const util = require('../libs/util/index');
+const help = require('./helpers/index');
+
+const assert = require('chai').assert;
+const _ = require('lodash');
+
+const Web3 = require('web3');
+const provider = new Web3.providers.HttpProvider('http://localhost:8545')
+const web3 = new Web3(provider);
+
+let HotelEvents;
+
+(process.env.TEST_BUILD)
+  ? HotelEvents = require('../dist/node/HotelEvents.js')
+  : HotelEvents = require('../libs/HotelEvents.js');
+
+describe('HotelEvents', function() {
+  let Manager;
+  let token;
+  let index;
+  let accounts;
+  let ownerAccount;
+  let augusto;
+  let hotelAddress;
+  let unitAddress;
+  let hotelEvents;
+
+  before(async function(){
+    accounts = await web3.eth.getAccounts();
+    ({
+      index,
+      token,
+      wallet
+    } = await help.createWindingTreeEconomy(accounts, web3));
+
+    ownerAccount = wallet["1"].address;
+    augusto = wallet["2"].address;
+  })
+
+  describe('subscribe', function() {
+    const fromDate = new Date('10/10/2020');
+    const daysAmount = 5;
+    const price = 1;
+    const guestData = web3.utils.toHex('guestData');
+
+    beforeEach(async function() {
+      ({
+        Manager,
+        hotelAddress,
+        unitAddress
+      } = await help.generateCompleteHotel(index.options.address, ownerAccount, 1.5, web3));
+
+      userOptions = {
+        account: augusto,
+        gasMargin: 1.5,
+        tokenAddress: token.options.address,
+        web3: web3
+      }
+
+      user = new User(userOptions);
+      hotelEvents = new HotelEvents(web3);
+
+      hotel = util.getInstance('Hotel', hotelAddress, {web3: web3});
+      await Manager.setDefaultLifPrice(hotelAddress, unitAddress, price);
+    });
+
+    it.skip('should subscribe to one hotels events and hear a Book event', async (done) => {
+      hotelEvents.subscribe(hotelAddress);
+      hotelEvents.on('Book', event => {
+        assert.isString(event.transactionHash);
+        assert.isNumber(event.blockNumber);
+        assert.isString(event.id);
+
+        assert.equal(event.address, hotel.options.address);
+        assert.equal(event.from, user.account);
+        assert.equal(event.fromDate.toString(), fromDate.toString());
+        assert.equal(event.unit, unitAddress);
+        assert.equal(event.daysAmount, daysAmount);
+        done();
+      });
+
+      await user.bookWithLif(
+        hotelAddress,
+        unitAddress,
+        fromDate,
+        daysAmount,
+        guestData
+      );
+    });
+
+    it.skip('should subscribe to one hotels events and hear a Book event');
+    it.skip('should subscribe to many hotels events and hear many Book events');
+    it.skip('should hear a CallStarted event');
+    it.skip('should hear a CallFinish event');
+  });
+});
+

--- a/test/User.js
+++ b/test/User.js
@@ -16,14 +16,10 @@ const web3 = new Web3(provider);
   : HotelManager = require('../libs/User.js');
 
 describe('User', function(){
-  const defaultGas = 400000;
-
   let Manager;
   let token;
   let index;
   let accounts;
-  let fundingSource;
-  let daoAccount;
   let ownerAccount;
   let augusto;
   let jakub;
@@ -31,53 +27,16 @@ describe('User', function(){
   let unitAddress;
 
   before(async function(){
-    const wallet = await web3.eth.accounts.wallet.create(4);
     accounts = await web3.eth.getAccounts();
+    ({
+      index,
+      token,
+      wallet
+    } = await help.createWindingTreeEconomy(accounts, web3));
 
-    fundingSource = accounts[0];
-    ownerAccount = wallet["0"].address;
-    daoAccount = wallet["1"].address;
+    ownerAccount = wallet["1"].address;
     augusto = wallet["2"].address;
     jakub = wallet["3"].address;
-
-    await util.fundAccount(fundingSource, ownerAccount, 50, web3);
-    await util.fundAccount(fundingSource, daoAccount, 50, web3);
-    await util.fundAccount(fundingSource, augusto, 50, web3);
-    await util.fundAccount(fundingSource, jakub, 50, web3);
-
-    index = await util.deployIndex({
-      owner: daoAccount,
-      gasMargin: 1.5,
-      web3: web3
-    });
-
-    token = await help.runTokenGenerationEvent();
-
-    const setLifData = await index.methods
-      .setLifToken(token.options.address)
-      .encodeABI();
-
-    const setLifOptions = {
-      from: daoAccount,
-      to: index.options.address,
-      gas: defaultGas,
-      data: setLifData
-    };
-
-    await web3.eth.sendTransaction(setLifOptions);
-
-    tokenFundingOptions = {
-      token: token,
-      sender: fundingSource,
-      value: 500,
-      web3: web3
-    };
-
-    tokenFundingOptions.receiver = augusto;
-    await help.sendTokens(tokenFundingOptions);
-
-    tokenFundingOptions.receiver = jakub;
-    await help.sendTokens(tokenFundingOptions);
   })
 
   describe('balanceCheck', function(){

--- a/test/helpers/economy.js
+++ b/test/helpers/economy.js
@@ -1,0 +1,79 @@
+const Token = require('./token');
+const misc = require('./misc');
+const util = require('../../libs/util/index');
+
+/**
+ * Test fixture that creates a LifToken, a WTIndex whose owner is `accounts[0]`, and funds four
+ * wallet accounts with 50 ETH (for gas fees). `wallet["0"]` creates the index and is meant
+ * to represent the dao. Additionally, `wallets["1-3"]` are funded with 500 Lif for bookings payments.
+ * This method is  meant to be run once in the `before` block of any suite that needs
+ * HotelManagers and clients.
+ * @param  {Array}  accounts  `web3.eth.accounts`
+ * @param  {Object} web3      web3 instance
+ * @return {Object}
+ * @example
+ * const accounts = await web3.eth.getAccounts();
+ * const {
+ *   index,  // WTIndex instance
+ *   token,  // LifToken instance (it's address is registered with the `index`)
+ *   wallet, // web3.eth.accounts.wallet w/ 4 accounts. (See above)
+ * } = await help.createWindingTreeEconomy(accounts)
+ */
+async function createWindingTreeEconomy(accounts, web3){
+  const defaultGas = 400000;
+  const wallet = await web3.eth.accounts.wallet.create(4);
+  const fundingSource = accounts[0];
+
+  await util.fundAccount(fundingSource, wallet["0"].address, 50, web3);
+  await util.fundAccount(fundingSource, wallet["1"].address, 50, web3);
+  await util.fundAccount(fundingSource, wallet["2"].address, 50, web3);
+  await util.fundAccount(fundingSource, wallet["3"].address, 50, web3);
+
+  const index = await util.deployIndex({
+    owner: wallet["0"].address,
+    gasMargin: 1.5,
+    web3: web3
+  });
+
+  const token = await Token.runTokenGenerationEvent();
+
+  const setLifData = await index.methods
+    .setLifToken(token.options.address)
+    .encodeABI();
+
+  const setLifOptions = {
+    from: wallet["0"].address,
+    to: index.options.address,
+    gas: defaultGas,
+    data: setLifData
+  };
+
+  await web3.eth.sendTransaction(setLifOptions);
+
+  const tokenFundingOptions = {
+    token: token,
+    sender: fundingSource,
+    value: 500,
+    web3: web3
+  };
+
+  tokenFundingOptions.receiver = wallet["1"].address;
+  await misc.sendTokens(tokenFundingOptions);
+
+  tokenFundingOptions.receiver = wallet["2"].address;
+  await misc.sendTokens(tokenFundingOptions);
+
+  tokenFundingOptions.receiver = wallet["3"].address;
+  await misc.sendTokens(tokenFundingOptions);
+
+  return {
+    index: index,
+    token: token,
+    wallet: wallet,
+  }
+}
+
+module.exports = {
+  createWindingTreeEconomy: createWindingTreeEconomy
+}
+

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,16 +1,22 @@
 const misc = require('./misc');
 const token = require('./token');
 const hotel = require('./hotel');
-
+const economy = require('./economy');
 
 module.exports = {
+  // -- Misc --
   sendTokens: misc.sendTokens,
 
+  // -- Token --
   increaseTimeTestRPC: token.increaseTimeTestRPC,
   increaseTimeTestRPCTo: token.increaseTimeTestRpcTo,
   simulateCrowdsale: token.simulateCrowdsale,
   runTokenGenerationEvent: token.runTokenGenerationEvent,
 
-  generateCompleteHotel: hotel.generateCompleteHotel
+  // -- Hotel --
+  generateCompleteHotel: hotel.generateCompleteHotel,
+
+  // -- Economy --
+  createWindingTreeEconomy: economy.createWindingTreeEconomy
 }
 


### PR DESCRIPTION
+ ~~Adds a HotelEvent class per #43.~~ 
+ Adds test setup and test skeleton for HotelEvent (see below).
+ Move some existing test setup logic to a `generateWindingTreeEconomy` fixture to simplify suites that need bookings logic.

Web3 1.0 needs WebSockets to push events and `testrpc` doesn't support WebSockets (yet). The only event method that works is `getPastEvents`. There's an open PR to fix this over at testrpc and hopefully they'll merge it soon. (They just got a full-time maintainer - he's great). Until then this is untestable.

Also of note - there's no`stopWatching`in the Web3 API anymore. 

I'd like to merge this just because the test fixture is useful. It's possible that the class itself is fine on Ropsten but idk without being able to run against it in the suite. 

@AugustoL if you approve I will run the build and docs before merging. 