### PR TITLE
Make guest data available on Booking event objects

### DIFF
--- a/libs/BookingData.js
+++ b/libs/BookingData.js
@@ -121,9 +121,6 @@ class BookingData {
         fromBlock: fromBlock
       });
 
-      if (!events.length)
-        continue;
-
       for (let event of events){
         const guestData = await util.getGuestData(event.transactionHash, this.context);
 
@@ -192,9 +189,6 @@ class BookingData {
 
         return found === -1;
       })
-
-      if (!unfinished.length)
-        continue;
 
       for(let event of unfinished){
         const guestData = await util.getGuestData(event.transactionHash, this.context);

--- a/libs/BookingData.js
+++ b/libs/BookingData.js
@@ -121,15 +121,23 @@ class BookingData {
         fromBlock: fromBlock
       });
 
-      events.forEach(event => bookings.push({
-        transactionHash: event.transactionHash,
-        blockNumber: event.blockNumber,
-        id: event.id,
-        from: event.returnValues.from,
-        unit: event.returnValues.unit,
-        fromDate: util.parseDate(event.returnValues.fromDay),
-        daysAmount: event.returnValues.daysAmount
-      }));
+      if (!events.length)
+        continue;
+
+      for (let event of events){
+        const guestData = await util.getGuestData(event.transactionHash, this.context);
+
+        bookings.push({
+          guestData: guestData,
+          transactionHash: event.transactionHash,
+          blockNumber: event.blockNumber,
+          id: event.id,
+          from: event.returnValues.from,
+          unit: event.returnValues.unit,
+          fromDate: util.parseDate(event.returnValues.fromDay),
+          daysAmount: event.returnValues.daysAmount
+        })
+      };
     }
     return bookings;
   };
@@ -185,13 +193,21 @@ class BookingData {
         return found === -1;
       })
 
-      unfinished.forEach(event => requests.push({
-        transactionHash: event.transactionHash,
-        blockNumber: event.blockNumber,
-        id: event.id,
-        from: event.returnValues.from,
-        dataHash: event.returnValues.dataHash,
-      }));
+      if (!unfinished.length)
+        continue;
+
+      for(let event of unfinished){
+        const guestData = await util.getGuestData(event.transactionHash, this.context);
+
+        requests.push({
+          guestData: guestData,
+          transactionHash: event.transactionHash,
+          blockNumber: event.blockNumber,
+          id: event.id,
+          from: event.returnValues.from,
+          dataHash: event.returnValues.dataHash,
+        })
+      };
     }
 
     return requests;

--- a/libs/HotelEvents.js
+++ b/libs/HotelEvents.js
@@ -37,11 +37,14 @@ class HotelEvents extends EventEmitter {
    * @param  {Object} err   web3 error object
    * @param  {Object} event web3 event object
    */
-  _emitEvent(err, event){
+  async _emitEvent(err, event){
     if(!event) return;
+
+    const guestData = await util.getGuestData(event.transactionHash, {web3: this.web3});
 
     const defaults = {
       address: event.address,
+      guestData: guestData,
       transactionHash: event.transactionHash,
       blockNumber: event.blockNumber,
       id: event.id,

--- a/libs/HotelEvents.js
+++ b/libs/HotelEvents.js
@@ -88,8 +88,6 @@ class HotelEvents extends EventEmitter {
       return this.subscriptions.findIndex(item => item === address) === -1;
     })
 
-    if (!hotelsToMonitor.length) return;
-
     let events;
     for (let address of hotelsToMonitor){
       const hotel = util.getInstance('Hotel', address, {web3: this.web3});

--- a/libs/User.js
+++ b/libs/User.js
@@ -66,7 +66,7 @@ class User {
    * @param  {Address}    unitAddress   Address of Unit contract being booked
    * @param  {Date}       fromDate      check in date
    * @param  {Number}     daysAmount    number of days to book
-   * @param  {String}     guestData     hex encoded guest data
+   * @param  {String}     guestData     guest data
    * @return {Promievent}
    */
   async bookWithLif(hotelAddress, unitAddress, fromDate, daysAmount, guestData) {
@@ -75,6 +75,7 @@ class User {
     const cost = await this.bookings.getLifCost(unitAddress, fromDay, daysAmount);
     const enough = await this.balanceCheck(cost);
     const available = await this.bookings.unitIsAvailable(unitAddress, fromDate, daysAmount);
+    const guestDataHex = this.context.web3.utils.toHex(guestData);
 
     if (!enough)
       return Promise.reject(errors.insufficientBalance);
@@ -87,7 +88,7 @@ class User {
       unitAddress,
       fromDay,
       daysAmount,
-      guestData
+      guestDataHex
     );
 
     const weiCost = util.lif2LifWei(cost, this.context);
@@ -118,13 +119,14 @@ class User {
    */
   async book(hotelAddress, unitAddress, fromDate, daysAmount, guestData){
     const fromDay = util.formatDate(fromDate);
+    const guestDataHex = this.context.web3.utils.toHex(guestData);
 
     const data = await this._compileBooking(
       hotelAddress,
       unitAddress,
       fromDay,
       daysAmount,
-      guestData
+      guestDataHex
     );
 
     const options = {

--- a/libs/util/index.js
+++ b/libs/util/index.js
@@ -31,6 +31,8 @@ module.exports = {
   bnToPrice: misc.bnToPrice,
   locationToUint: misc.locationToUint,
   locationFromUint: misc.locationFromUint,
+  getLifGuestData: misc.getLifGuestData,
+  getGuestData: misc.getGuestData,
   addGasMargin: misc.addGasMargin,
   getInstance: misc.getInstance,
   fundAccount: misc.fundAccount,

--- a/libs/util/misc.js
+++ b/libs/util/misc.js
@@ -139,6 +139,27 @@ function bytes32ToString(hex){
 
 //----------------------------------------- Web3 Helpers -------------------------------------------
 
+/**
+ * Extracts the guest data from an instant payment Booking initiated by
+ * a `token.approveData` transaction.
+ * @param  {String} hash    transaction hash, available on the `CallStarted` event
+ * @param  {Object} context execution context of the class ()
+ * @return {String}      plain text guest data. If this is JSON it will need to be parsed.
+ */
+async function getGuestData(hash, context){
+  let guestData;
+  let tx = await context.web3.eth.getTransaction(hash);
+  let method = abiDecoder.decodeMethod(tx.input);
+
+  if (method.name === 'approveData'){
+    const paramData = method.params.filter(call => call.name === 'data')[0].value;
+    method = abiDecoder.decodeMethod(paramData);
+  }
+
+  guestData = method.params.filter(call => call.name === 'privateData')[0].value;
+  return context.web3.utils.toUtf8(guestData);
+}
+
 async function addGasMargin(gas, context){
   const id = await context.web3.eth.net.getId();
   return (id === testnetId)
@@ -215,6 +236,7 @@ module.exports = {
   locationFromUint: locationFromUint,
 
   // Web3 helpers
+  getGuestData: getGuestData,
   addGasMargin: addGasMargin,
   getInstance: getInstance,
   fundAccount: fundAccount,

--- a/test/BookingData.js
+++ b/test/BookingData.js
@@ -89,7 +89,7 @@ describe('BookingData', function() {
     const fromDate = new Date('10/10/2020');
     const daysAmount = 5;
     const price = 1;
-    const guestData = web3.utils.toHex('guestData');
+    const guestData = 'guestData';
 
     it('gets a booking for a hotel', async() => {
       await user.bookWithLif(
@@ -100,6 +100,7 @@ describe('BookingData', function() {
         guestData
       );
       const bookings = await data.getBookings(hotelAddress);
+
       const booking = bookings[0];
 
       assert.equal(bookings.length, 1);
@@ -107,6 +108,7 @@ describe('BookingData', function() {
       assert.isNumber(booking.blockNumber);
       assert.isString(booking.id);
 
+      assert.equal(booking.guestData, guestData);
       assert.equal(booking.from, user.account);
       assert.equal(booking.fromDate.toString(), fromDate.toString());
       assert.equal(booking.unit, unitAddress);
@@ -200,7 +202,7 @@ describe('BookingData', function() {
     const fromDate = new Date('10/10/2020');
     const daysAmount = 5;
     const price = 1;
-    const guestData = web3.utils.toHex('guestData');
+    const guestData = 'guestData';
 
     beforeEach(async () => await Manager.setRequireConfirmation(hotelAddress, true));
 
@@ -221,6 +223,7 @@ describe('BookingData', function() {
       assert.isString(request.id);
       assert.isString(request.dataHash);
 
+      assert.equal(request.guestData, guestData);
       assert.equal(request.from, user.account);
     });
 

--- a/test/HotelEvents.js
+++ b/test/HotelEvents.js
@@ -42,7 +42,7 @@ describe('HotelEvents', function() {
     const fromDate = new Date('10/10/2020');
     const daysAmount = 5;
     const price = 1;
-    const guestData = web3.utils.toHex('guestData');
+    const guestData = 'guestData';
 
     beforeEach(async function() {
       ({
@@ -72,6 +72,7 @@ describe('HotelEvents', function() {
         assert.isNumber(event.blockNumber);
         assert.isString(event.id);
 
+        assert.equal(event.guestData, guestData);
         assert.equal(event.address, hotel.options.address);
         assert.equal(event.from, user.account);
         assert.equal(event.fromDate.toString(), fromDate.toString());


### PR DESCRIPTION
+ Adds a helper method that extracts the `guestData` param from transactions whose hashes are captured by the event logs.
+ Adds `guestData` field to the event objects returned by `BookingData` and `HotelEvents`
+ Lets the `guestData` param of the Book methods be a string, and hex encodes within the lib.
+ Updates the tests to validate the above.
