### PR TITLE
Add missing adress of unitTypes in getHotel

### DIFF
--- a/libs/utils/hotel.js
+++ b/libs/utils/hotel.js
@@ -181,7 +181,7 @@ async function getHotelInfo(wtHotel, context){
 
       const name = context.web3.utils.toUtf8(typeName);
       unitTypes[name] = {};
-      unitTypes[name].address = instance.address;
+      unitTypes[name].address = instance._address;
 
       // UnitType Amenities
       const amenities = await instance.methods.getAmenities().call();

--- a/test/HotelManager.js
+++ b/test/HotelManager.js
@@ -189,6 +189,7 @@ describe('HotelManager', function() {
 
       assert(hotel.unitTypeNames.includes(typeName));
       assert.isDefined(hotel.unitTypes[typeName]);
+      assert.isDefined(hotel.unitTypes[typeName].address);
     });
 
     it('addUnitType: initializes info correctly', async() => {


### PR DESCRIPTION
The address should be received from `_address` and not `address` in the UnitType instance.
Added assert in test to verify is not undefined.