### PR TITLE
chore: Deploy to npm after everything is done and actually build the lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
         - npm run test-build-web
     - stage: NPM release
       script: echo 'Deploying to NPM...'
+      before_deploy: npm run build
       deploy:
         provider: npm
         email: augusto.lemble@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,14 @@ jobs:
       script:
         - set -e
         - npm run test-build-web
-deploy:
-  provider: npm
-  email: augusto.lemble@gmail.com
-  skip_cleanup: true
-  api_key: $NPM_TOKEN
-  on:
-    repo: windingtree/wt-js-libs
-    tags: true
+    - stage: NPM release
+      script: echo 'Deploying to NPM...'
+      deploy:
+        provider: npm
+        email: augusto.lemble@gmail.com
+        skip_cleanup: true
+        api_key: $NPM_TOKEN
+        on:
+          repo: windingtree/wt-js-libs
+          tags: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
         - set -e
         - npm run test-build-web
     - stage: NPM release
+      if: branch = master
       script: echo 'Deploying to NPM...'
       before_deploy: npm run build
       deploy:


### PR DESCRIPTION
This should make sure that integration tests are run before actual npm deployment and the library is actually built