### PR TITLE
chore: Limit npm deploy to tags only on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - set -e
         - npm run test-build-web
     - stage: NPM release
-      if: branch = master
+      if: tag IS present
       script: echo 'Deploying to NPM...'
       before_deploy: npm run build
       deploy:


### PR DESCRIPTION
This will actually serve as #115, because travis has a strange behavior regarding tags.