### PR TITLE
web3 backed future api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage
 .nyc_output
 .nyc_coverage
 build/contracts
+test/utils/compiled

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "scripts": {
     "flow": "flow",
     "lint": "eslint src test test-build",
-    "test": "rimraf .nyc_output .nyc_coverage && npm run test-json",
+    "test": "rimraf .nyc_output .nyc_coverage && npm run test-json && npm run test-web3",
     "test-json": "TESTED_NETWORK=json npm run test-runner",
+    "test-web3": "./test/utils/scripts/localtestnet.sh",
     "test-runner": "nyc --clean=false --reporter=text mocha \"test/**/*.spec.js\" --timeout 20000 --require babel-register --require babel-polyfill",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "clean": "rimraf dist",

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ class WTLibs {
 
   constructor (options: WtLibsOptionsType) {
     this.options = options || {};
-    this.options.networkConnectorType = this.options.networkConnectorType || 'json';
+    this.options.networkConnectorType = this.options.networkConnectorType || 'web3';
     this.network = Network.createInstance(this.options.networkConnectorType, this.options.networkOptions);
   }
 

--- a/src/network/connectors/json/data-providers/wt-index.js
+++ b/src/network/connectors/json/data-providers/wt-index.js
@@ -24,24 +24,8 @@ class WTIndexDataProvider implements WTIndexDataProviderInterface {
     for (let addr in this.source.index.hotels) {
       let hotel = this.source.index.hotels[addr];
       // Initial data might lack data accessors
-      this.source.index.hotels[addr] = this._addAsyncGetters(hotel);
+      this.source.index.hotels[addr] = hotel;
     }
-  }
-
-  _addAsyncGetters (hotel: Object): HotelInterface {
-    if (!hotel.getAddress) {
-      hotel.getAddress = async (): Promise<?string> => hotel.address;
-    }
-    if (!hotel.getName) {
-      hotel.getName = async (): Promise<?string> => hotel.name;
-    }
-    if (!hotel.getDescription) {
-      hotel.getDescription = async (): Promise<?string> => hotel.description;
-    }
-    if (!hotel.getManager) {
-      hotel.getManager = async (): Promise<?string> => hotel.manager;
-    }
-    return hotel;
   }
 
   async addHotel (hotelData: HotelDataInterface): Promise<HotelInterface> {
@@ -52,7 +36,7 @@ class WTIndexDataProvider implements WTIndexDataProviderInterface {
       throw new Error('Cannot add hotel: Missing description');
     }
     const randomId = '0x000' + Object.keys(this.source.index.hotels).length;
-    this.source.index.hotels[randomId] = this._addAsyncGetters(Object.assign(hotelData, { address: randomId }));
+    this.source.index.hotels[randomId] = Object.assign(hotelData, { address: randomId });
     return this.source.index.hotels[randomId];
   }
 
@@ -65,7 +49,7 @@ class WTIndexDataProvider implements WTIndexDataProviderInterface {
   }
 
   async updateHotel (hotel: HotelInterface): Promise<HotelInterface> {
-    const hotelAddress: ?string = await hotel.getAddress();
+    const hotelAddress: ?string = await hotel.address;
     if (hotelAddress && this.source.index.hotels[hotelAddress]) {
       return Object.assign(this.source.index.hotels[hotelAddress], hotel);
     }
@@ -73,9 +57,9 @@ class WTIndexDataProvider implements WTIndexDataProviderInterface {
   }
 
   async removeHotel (hotel: HotelInterface): Promise<boolean> {
-    const address = await hotel.getAddress();
+    const address = await hotel.address;
     try {
-      if (address && this.source.index.hotels[address] && this.source.index.hotels[address].manager === await hotel.getManager()) {
+      if (address && this.source.index.hotels[address] && this.source.index.hotels[address].manager === await hotel.manager) {
         delete this.source.index.hotels[address];
         return true;
       }

--- a/src/network/connectors/web3/backed-by-blockchain.js
+++ b/src/network/connectors/web3/backed-by-blockchain.js
@@ -1,0 +1,152 @@
+// This is so meta and generic that flow is hard to do here
+import _ from 'lodash';
+// type FieldStateType = 'unsynced' | 'synced' | 'dirty';
+
+class BackedByBlockchain {
+  constructor () {
+    this.address = undefined;
+    this.__obsoleteFlag = false;
+    this.__localData = {};
+    this.__networkData = {};
+    this.__fieldStates = {};
+    this.__fieldKeys = [];
+  }
+
+  setOptions (options) {
+    this.__options = options;
+    this.__fieldKeys = Object.keys(options.fields);
+
+    for (let i = 0; i < this.__fieldKeys.length; i++) {
+      let fieldName = this.__fieldKeys[i];
+      this.__fieldStates[fieldName] = 'unsynced';
+      Object.defineProperty(this, fieldName, {
+        configurable: false,
+        enumerable: true,
+        get: async () => {
+          return this._genericGetter(fieldName);
+        },
+        set: (newValue) => {
+          this._genericSetter(fieldName, newValue);
+        },
+      });
+    }
+  }
+
+  isObsolete () {
+    return this.__obsoleteFlag;
+  }
+
+  markObsolete () {
+    this.__obsoleteFlag = true;
+  }
+
+  async _genericGetter (property) {
+    if (this.isObsolete()) {
+      throw new Error('This object was destroyed on the network!');
+    }
+    // This is a totally new instance backed by an actual contract
+    if (this.address && (this.__fieldStates[property] === 'unsynced')) {
+      await this._syncDataFromNetwork();
+    }
+
+    return this.__localData[property];
+  }
+
+  _genericSetter (property, newValue) {
+    if (this.isObsolete()) {
+      throw new Error('This object was destroyed on the network!');
+    }
+    if (this.__localData[property] !== newValue) {
+      this.__localData[property] = newValue;
+      this.__fieldStates[property] = 'dirty';
+    }
+  }
+
+  async _fetchDataFromNetwork () {
+    if (!this.address) {
+      throw new Error('Cannot fetch data without network address');
+    }
+    const networkGetters = [];
+    const contract = await this._getContractInstance();
+    for (let i = 0; i < this.__fieldKeys.length; i++) {
+      const networkGetter = this.__options.fields[this.__fieldKeys[i]].networkGetter;
+      if (networkGetter && this.__fieldStates[this.__fieldKeys[i]] === 'unsynced') {
+        networkGetters.push(networkGetter(contract));
+      }
+    }
+    if (networkGetters.length) {
+      const attributes = await (Promise.all(networkGetters));
+      for (let i = 0; i < this.__fieldKeys.length; i++) {
+        this.__networkData[this.__fieldKeys[i]] = attributes[i];
+      }
+    }
+    return this.__networkData;
+  }
+
+  async _syncDataFromNetwork () {
+    try {
+      await this._fetchDataFromNetwork();
+      // Copy over data from networkData in the main storage
+      for (let i = 0; i < this.__fieldKeys.length; i++) {
+        // Do not update user-modified fields
+        // TODO deal with 3rd party data modificiation on network
+        if (this.__networkData[this.__fieldKeys[i]] !== this.__localData[this.__fieldKeys[i]] && this.__fieldStates[this.__fieldKeys[i]] !== 'dirty') {
+          this.__localData[this.__fieldKeys[i]] = this.__networkData[this.__fieldKeys[i]];
+          this.__fieldStates[this.__fieldKeys[i]] = 'synced';
+        }
+      }
+    } catch (err) {
+      // TODO better error handling
+      // Address where there is no hotel deployed / any other error
+      throw new Error('Cannot call hotel contract on ' + (this.address || '') + ': ' + err.message);
+    }
+  }
+
+  // https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript-jquery
+  __hashCode (text) {
+    var hash = 0, i, chr;
+    if (text.length === 0) {
+      return hash;
+    }
+    for (i = 0; i < text.length; i++) {
+      chr = text.charCodeAt(i);
+      hash = ((hash << 5) - hash) + chr;
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+  }
+
+  async updateOnNetwork (transactionOptions) {
+    await this._syncDataFromNetwork();
+    const networkSetters = [];
+    const networkSettersHashCodes = {};
+    const contract = await this._getContractInstance();
+    for (let i = 0; i < this.__fieldKeys.length; i++) {
+      const networkSetter = this.__options.fields[this.__fieldKeys[i]].networkSetter;
+      if (networkSetter && this.__fieldStates[this.__fieldKeys[i]] === 'dirty') {
+        // deduplicate equal calls
+        let setterHashCode = this.__hashCode(networkSetter.toString());
+        if (!networkSettersHashCodes[setterHashCode]) {
+          networkSettersHashCodes[setterHashCode] = true;
+          networkSetters.push(networkSetter(contract, _.cloneDeep(transactionOptions)));
+        }
+      }
+    }
+    // TODO check results
+    await (Promise.all(networkSetters));
+    return this;
+  }
+
+  async createOnNetwork (transactionOptions) {
+    // TODO create default implementation that deploys contract
+    // to network
+    throw new Error('This has to be implemented in a subclass!');
+  }
+
+  async removeFromNetwork (transactionOptions) {
+    // by default you can not remove contract from network
+    throw new Error('This has to be implemented in a subclass!');
+  }
+}
+
+export default BackedByBlockchain;

--- a/src/network/connectors/web3/contracts.js
+++ b/src/network/connectors/web3/contracts.js
@@ -1,0 +1,51 @@
+import TruffleContract from 'truffle-contract';
+import WTIndexContractMetadata from '@windingtree/wt-contracts/build/contracts/WTIndex';
+import HotelContractMetadata from '@windingtree/wt-contracts/build/contracts/Hotel';
+
+// dirty hack for web3@1.0.0 support for localhost testrpc, see
+// https://github.com/trufflesuite/truffle-contract/issues/56#issuecomment-331084530
+function hackInSendAsync (instance) {
+  if (typeof instance.currentProvider.sendAsync !== 'function') {
+    instance.currentProvider.sendAsync = function () {
+      return instance.currentProvider.send.apply(
+        instance.currentProvider, arguments
+      );
+    };
+  }
+  return instance;
+}
+
+function getContractWithProvider (metadata, provider) {
+  let contract = new TruffleContract(metadata);
+  contract.setProvider(provider);
+  contract = hackInSendAsync(contract);
+  return contract;
+}
+
+class Contracts {
+  static async getIndexInstance (address, web3Provider) {
+    // This does not support await syntax
+    return getContractWithProvider(WTIndexContractMetadata, web3Provider).at(address)
+      .then((instance) => {
+        return instance;
+      })
+      .catch((err) => {
+        // TODO better error handling
+        // No code at address
+        throw new Error('Cannot get index instance at ' + address + ': ' + err.message);
+      });
+  }
+  static async getHotelInstance (address, web3Provider) {
+    // This does not support await syntax
+    return getContractWithProvider(HotelContractMetadata, web3Provider).at(address)
+      .then((instance) => {
+        return instance;
+      })
+      .catch((err) => {
+        // TODO better error handling
+        // No code at address
+        throw new Error('Cannot get hotel instance at ' + address + ': ' + err.message);
+      });
+  }
+}
+export default Contracts;

--- a/src/network/connectors/web3/data-providers/hotel.js
+++ b/src/network/connectors/web3/data-providers/hotel.js
@@ -1,0 +1,203 @@
+// @flow
+import type { HotelDataInterface, HotelInterface } from '../../../interfaces';
+import Web3Connector from '../';
+import Contracts from '../contracts';
+import Utils from '../utils';
+
+type ContractStateType = 'fresh' | 'downloaded' | 'dirty' | 'synced';
+
+class HotelDataProvider implements HotelInterface {
+  state: ContractStateType;
+  address: ?string;
+  connector: Web3Connector;
+  indexContract: Object;
+  deployedHotel: Object;
+
+  /* Data */
+  networkData: HotelDataInterface;
+  localData: HotelDataInterface;
+
+  static createInstance (connector: Web3Connector, indexContract: Object, address?: string): HotelDataProvider {
+    return new HotelDataProvider(connector, indexContract, address);
+  }
+
+  constructor (connector: Web3Connector, indexContract: Object, address?: string) {
+    this.address = address;
+    this.connector = connector;
+    this.indexContract = indexContract;
+    this.networkData = {};
+    this.localData = {};
+    this.state = 'fresh';
+  }
+
+  /* Getters */
+  async _genericGetter (property: string): any { // eslint-disable-line flowtype/no-weak-types
+    // This is a totally new instance
+    if (this.state === 'fresh' && this.address) {
+      await this._loadFromNetwork();
+    }
+    return this.localData[property];
+  }
+
+  async getAddress (): Promise<?string> {
+    return this._genericGetter('address');
+  }
+
+  async getName (): Promise<?string> {
+    return this._genericGetter('name');
+  }
+
+  async getDescription (): Promise<?string> {
+    return this._genericGetter('description');
+  }
+
+  async getManager (): Promise<?string> {
+    return this._genericGetter('manager');
+  }
+
+  /* Setters */
+  _genericSetter (property: string, newValue: any) { // eslint-disable-line flowtype/no-weak-types
+    if (this.localData[property] !== newValue) {
+      this.localData[property] = newValue;
+      this.state = 'dirty';
+    }
+  }
+
+  set name (name: ?string) {
+    if (!name) {
+      throw new Error('Missing name');
+    }
+    this._genericSetter('name', name);
+  }
+  
+  set description (description: ?string) {
+    if (!description) {
+      throw new Error('Missing description');
+    }
+    this._genericSetter('description', description);
+  }
+
+  set manager (manager: ?string) {
+    this._genericSetter('manager', manager);
+  }
+
+  setLocalData (newData: HotelDataInterface) {
+    // TODO deal with nulling the data
+    if (!newData.name) {
+      throw new Error('Missing name');
+    }
+    if (!newData.description) {
+      throw new Error('Missing description');
+    }
+    this.name = newData.name;
+    this.description = newData.description;
+    this.manager = newData.manager;
+  }
+
+  /* Network communication */
+  async _getDeployedHotel (): Promise<Object> {
+    // We cannot use getAddress here because it would get stuck in an infinite loop
+    if (!this.address) {
+      throw new Error('Cannot get hotel instance without address');
+    }
+    if (!this.deployedHotel) {
+      this.deployedHotel = await Contracts.getHotelInstance(this.address, this.connector.web3.currentProvider);
+    }
+    return this.deployedHotel;
+  }
+
+  async _getHotelIndexInManagerList (): Promise<number> {
+    const address = await this.getAddress();
+    if (!address) {
+      throw new Error('Cannot get hotel index without address');
+    }
+    const manager = await this.getManager();
+    if (!manager) {
+      throw new Error('Cannot get hotel index without manager');
+    }
+    const managersHotels = await this.indexContract.getHotelsByManager(manager);
+    const hotelIndex = managersHotels.indexOf(address);
+    if (hotelIndex < 0) {
+      // TODO improve this
+      throw new Error((address || 'unknown') + ' not found in manager ' + (manager || 'unknown') + ' collection');
+    }
+    return hotelIndex;
+  }
+
+  async _fetchFromNetwork (): Promise<HotelDataInterface> {
+    const hotelContract = await this._getDeployedHotel();
+    const attributes: Array<string> = await (Promise.all([
+      hotelContract.name(),
+      hotelContract.description(),
+      hotelContract.manager(),
+    ]): any); // eslint-disable-line flowtype/no-weak-types
+    this.state = 'downloaded';
+    Object.assign(this.networkData, {
+      address: this.address,
+      name: attributes[0],
+      description: attributes[1],
+      manager: attributes[2],
+    });
+    return this.networkData;
+  }
+
+  async _loadFromNetwork (): Promise<?HotelDataProvider> {
+    try {
+      const networkData = await this._fetchFromNetwork();
+      // Copy over data from networkData in the main storage
+      Object.assign(this.localData, networkData);
+      this.state = 'synced';
+      return this;
+    } catch (err) {
+      // TODO better error handling
+      // Address where there is no hotel deployed / any other error
+      throw new Error('Cannot call hotel contract on ' + (this.address || '') + ': ' + err.message);
+    }
+  }
+
+  async createOnNetwork (transactionOptions: Object): Promise<HotelDataProvider> {
+    const estimate = await this.indexContract.registerHotel.estimateGas(this.localData.name, this.localData.description, transactionOptions);
+    await this.indexContract.registerHotel(this.localData.name, this.localData.description, Object.assign(transactionOptions, {
+      gas: this.connector.applyGasCoefficient(estimate),
+    }));
+    // TODO check result
+    // TODO simplify as setdata with HotelDataInterface, re-use updateOnNetwork
+    this.state = 'synced';
+    // TODO pass hotel address into the log event if possible, that will be much more efficient
+    const managersHotels = await this.indexContract.getHotelsByManager(this.localData.manager);
+    // TODO We expect that no other write happened in the meantime, that's plain wrong
+    this.localData.address = managersHotels.pop();
+    if (!this.address) {
+      this.address = this.localData.address;
+    }
+    return this;
+  }
+
+  async updateOnNetwork (transactionOptions: Object): Promise<HotelDataProvider> {
+    const hotelContract = await this._getDeployedHotel();
+    // TODO ensure I have all data from network before syncing back, local data is always right if
+    // networkdata did not change since last synced block
+    // TODO implement smart diffing
+    // TODO make update calls smart based on updated fields
+    const data = Utils.encodeMethodCall(hotelContract.abi, 'editInfo', [await this.getName(), await this.getDescription()]);
+    const hotelIndex = await this._getHotelIndexInManagerList();
+    const estimate = await this.indexContract.callHotel.estimateGas(hotelIndex, data, transactionOptions);
+    await this.indexContract.callHotel(hotelIndex, data, Object.assign(transactionOptions, {
+      gas: this.connector.applyGasCoefficient(estimate),
+    }));
+    // TODO check result
+    return this;
+  }
+
+  async removeFromNetwork (transactionOptions: Object): Promise<boolean> {
+    const hotelIndex = await this._getHotelIndexInManagerList();
+    const estimate = await this.indexContract.deleteHotel.estimateGas(hotelIndex, transactionOptions);
+    const result = await this.indexContract.deleteHotel(hotelIndex, Object.assign(transactionOptions, {
+      gas: this.connector.applyGasCoefficient(estimate),
+    }));
+    // TODO check result
+    return !!result.tx;
+  }
+}
+
+export default HotelDataProvider;

--- a/src/network/connectors/web3/data-providers/hotel.js
+++ b/src/network/connectors/web3/data-providers/hotel.js
@@ -1,84 +1,53 @@
 // @flow
 import type { HotelDataInterface, HotelInterface } from '../../../interfaces';
+import BackedByBlockchain from '../backed-by-blockchain';
 import Web3Connector from '../';
 import Contracts from '../contracts';
 import Utils from '../utils';
 
-type ContractStateType = 'fresh' | 'downloaded' | 'dirty' | 'synced';
-
-class HotelDataProvider implements HotelInterface {
-  state: ContractStateType;
-  address: ?string;
+class HotelDataProvider extends BackedByBlockchain implements HotelInterface {
   connector: Web3Connector;
   indexContract: Object;
-  deployedHotel: Object;
-
-  /* Data */
-  networkData: HotelDataInterface;
-  localData: HotelDataInterface;
+  contractInstance: Object;
 
   static createInstance (connector: Web3Connector, indexContract: Object, address?: string): HotelDataProvider {
-    return new HotelDataProvider(connector, indexContract, address);
+    const hotel = new HotelDataProvider(connector, indexContract, address);
+    hotel.initialize();
+    return hotel;
   }
 
   constructor (connector: Web3Connector, indexContract: Object, address?: string) {
+    super();
     this.address = address;
     this.connector = connector;
     this.indexContract = indexContract;
-    this.networkData = {};
-    this.localData = {};
-    this.state = 'fresh';
   }
 
-  /* Getters */
-  async _genericGetter (property: string): any { // eslint-disable-line flowtype/no-weak-types
-    // This is a totally new instance
-    if (this.state === 'fresh' && this.address) {
-      await this._loadFromNetwork();
-    }
-    return this.localData[property];
-  }
-
-  async getAddress (): Promise<?string> {
-    return this._genericGetter('address');
-  }
-
-  async getName (): Promise<?string> {
-    return this._genericGetter('name');
-  }
-
-  async getDescription (): Promise<?string> {
-    return this._genericGetter('description');
-  }
-
-  async getManager (): Promise<?string> {
-    return this._genericGetter('manager');
-  }
-
-  /* Setters */
-  _genericSetter (property: string, newValue: any) { // eslint-disable-line flowtype/no-weak-types
-    if (this.localData[property] !== newValue) {
-      this.localData[property] = newValue;
-      this.state = 'dirty';
-    }
-  }
-
-  set name (name: ?string) {
-    if (!name) {
-      throw new Error('Missing name');
-    }
-    this._genericSetter('name', name);
-  }
-  
-  set description (description: ?string) {
-    if (!description) {
-      throw new Error('Missing description');
-    }
-    this._genericSetter('description', description);
-  }
-
-  set manager (manager: ?string) {
-    this._genericSetter('manager', manager);
+  initialize () {
+    const updateNameAndDesc = async (contractInstance: Object, transactionOptions: Object): Object => {
+      return this._editNameAndDescription(contractInstance, transactionOptions);
+    };
+    this.setOptions({
+      fields: {
+        name: {
+          networkGetter: async (contractInstance: Object): Promise<?string> => {
+            return contractInstance.name();
+          },
+          networkSetter: updateNameAndDesc,
+        },
+        description: {
+          networkGetter: async (contractInstance: Object): Promise<?string> => {
+            return contractInstance.description();
+          },
+          networkSetter: updateNameAndDesc,
+        },
+        manager: {
+          networkGetter: async (contractInstance: Object): Promise<?string> => {
+            return contractInstance.manager();
+          },
+        },
+      },
+    });
   }
 
   setLocalData (newData: HotelDataInterface) {
@@ -91,101 +60,62 @@ class HotelDataProvider implements HotelInterface {
     }
     this.name = newData.name;
     this.description = newData.description;
-    this.manager = newData.manager;
+    this.manager = newData.manager || this.manager;
   }
 
-  /* Network communication */
-  async _getDeployedHotel (): Promise<Object> {
-    // We cannot use getAddress here because it would get stuck in an infinite loop
+  async _getContractInstance (): Promise<Object> {
     if (!this.address) {
       throw new Error('Cannot get hotel instance without address');
     }
-    if (!this.deployedHotel) {
-      this.deployedHotel = await Contracts.getHotelInstance(this.address, this.connector.web3.currentProvider);
+    if (!this.contractInstance) {
+      this.contractInstance = await Contracts.getHotelInstance(this.address, this.connector.web3.currentProvider);
     }
-    return this.deployedHotel;
+    return this.contractInstance;
   }
 
   async _getHotelIndexInManagerList (): Promise<number> {
-    const address = await this.getAddress();
-    if (!address) {
+    // TODO this can be cached/memoized for a decent amount of time
+    if (!this.address) {
       throw new Error('Cannot get hotel index without address');
     }
-    const manager = await this.getManager();
+    const manager = await this.manager;
     if (!manager) {
       throw new Error('Cannot get hotel index without manager');
     }
     const managersHotels = await this.indexContract.getHotelsByManager(manager);
-    const hotelIndex = managersHotels.indexOf(address);
+    const hotelIndex = managersHotels.indexOf(this.address);
     if (hotelIndex < 0) {
-      // TODO improve this
-      throw new Error((address || 'unknown') + ' not found in manager ' + (manager || 'unknown') + ' collection');
+      // TODO improve error handling
+      throw new Error((this.address || 'unknown') + ' not found in manager ' + (manager || 'unknown') + ' collection');
     }
     return hotelIndex;
   }
 
-  async _fetchFromNetwork (): Promise<HotelDataInterface> {
-    const hotelContract = await this._getDeployedHotel();
-    const attributes: Array<string> = await (Promise.all([
-      hotelContract.name(),
-      hotelContract.description(),
-      hotelContract.manager(),
-    ]): any); // eslint-disable-line flowtype/no-weak-types
-    this.state = 'downloaded';
-    Object.assign(this.networkData, {
-      address: this.address,
-      name: attributes[0],
-      description: attributes[1],
-      manager: attributes[2],
-    });
-    return this.networkData;
-  }
-
-  async _loadFromNetwork (): Promise<?HotelDataProvider> {
-    try {
-      const networkData = await this._fetchFromNetwork();
-      // Copy over data from networkData in the main storage
-      Object.assign(this.localData, networkData);
-      this.state = 'synced';
-      return this;
-    } catch (err) {
-      // TODO better error handling
-      // Address where there is no hotel deployed / any other error
-      throw new Error('Cannot call hotel contract on ' + (this.address || '') + ': ' + err.message);
-    }
+  async _editNameAndDescription (contractInstance: Object, transactionOptions: Object): Object {
+    const data = Utils.encodeMethodCall(contractInstance.abi, 'editInfo', [await this.name, await this.description]);
+    const hotelIndex = await this._getHotelIndexInManagerList();
+    const estimate = await this.indexContract.callHotel.estimateGas(hotelIndex, data, transactionOptions);
+    return this.indexContract.callHotel(hotelIndex, data, Object.assign(transactionOptions, {
+      gas: this.connector.applyGasCoefficient(estimate),
+    }));
   }
 
   async createOnNetwork (transactionOptions: Object): Promise<HotelDataProvider> {
-    const estimate = await this.indexContract.registerHotel.estimateGas(this.localData.name, this.localData.description, transactionOptions);
-    await this.indexContract.registerHotel(this.localData.name, this.localData.description, Object.assign(transactionOptions, {
+    // We have to access __localData directly to prevent looping into network communication
+    const estimate = await this.indexContract.registerHotel.estimateGas(this.__localData.name, this.__localData.description, transactionOptions);
+    await this.indexContract.registerHotel(this.__localData.name, this.__localData.description, Object.assign({}, transactionOptions, {
       gas: this.connector.applyGasCoefficient(estimate),
     }));
     // TODO check result
-    // TODO simplify as setdata with HotelDataInterface, re-use updateOnNetwork
-    this.state = 'synced';
     // TODO pass hotel address into the log event if possible, that will be much more efficient
-    const managersHotels = await this.indexContract.getHotelsByManager(this.localData.manager);
+    const managersHotels = await this.indexContract.getHotelsByManager(this.__localData.manager);
     // TODO We expect that no other write happened in the meantime, that's plain wrong
-    this.localData.address = managersHotels.pop();
+    this.__localData.address = managersHotels.pop();
     if (!this.address) {
-      this.address = this.localData.address;
+      this.address = this.__localData.address;
     }
-    return this;
-  }
-
-  async updateOnNetwork (transactionOptions: Object): Promise<HotelDataProvider> {
-    const hotelContract = await this._getDeployedHotel();
-    // TODO ensure I have all data from network before syncing back, local data is always right if
-    // networkdata did not change since last synced block
-    // TODO implement smart diffing
-    // TODO make update calls smart based on updated fields
-    const data = Utils.encodeMethodCall(hotelContract.abi, 'editInfo', [await this.getName(), await this.getDescription()]);
-    const hotelIndex = await this._getHotelIndexInManagerList();
-    const estimate = await this.indexContract.callHotel.estimateGas(hotelIndex, data, transactionOptions);
-    await this.indexContract.callHotel(hotelIndex, data, Object.assign(transactionOptions, {
-      gas: this.connector.applyGasCoefficient(estimate),
-    }));
-    // TODO check result
+    // sync all other data into network
+    await this.updateOnNetwork(transactionOptions);
     return this;
   }
 
@@ -196,6 +126,7 @@ class HotelDataProvider implements HotelInterface {
       gas: this.connector.applyGasCoefficient(estimate),
     }));
     // TODO check result
+    this.markObsolete();
     return !!result.tx;
   }
 }

--- a/src/network/connectors/web3/data-providers/wt-index.js
+++ b/src/network/connectors/web3/data-providers/wt-index.js
@@ -45,7 +45,7 @@ class WTIndexDataProvider implements WTIndexDataProviderInterface {
     try {
       // We need to separate calls to be able to properly catch exceptions
       const updatedHotel = await hotel.updateOnNetwork({
-        from: await hotel.getManager(),
+        from: await hotel.manager,
         to: this.address,
       });
       return updatedHotel;
@@ -59,7 +59,7 @@ class WTIndexDataProvider implements WTIndexDataProviderInterface {
     try {
       // We need to separate calls to be able to properly catch exceptions
       const result = ((hotel: any): HotelDataProvider).removeFromNetwork({ // eslint-disable-line flowtype/no-weak-types
-        from: await hotel.getManager(),
+        from: await hotel.manager,
         to: this.address,
       });
       return result;

--- a/src/network/connectors/web3/data-providers/wt-index.js
+++ b/src/network/connectors/web3/data-providers/wt-index.js
@@ -1,0 +1,112 @@
+// @flow
+
+import type { WTIndexDataProviderInterface, HotelInterface, HotelDataInterface } from '../../../interfaces';
+import Web3Connector from '../';
+import Contracts from '../contracts';
+import HotelDataProvider from './hotel';
+import Utils from '../utils';
+
+class WTIndexDataProvider implements WTIndexDataProviderInterface {
+  address: string;
+  connector: Web3Connector;
+  deployedIndex: Object; // TODO get rid of Object type
+
+  static async createInstance (indexAddress: string, connector: Web3Connector): Promise<WTIndexDataProvider> {
+    return new WTIndexDataProvider(indexAddress, connector);
+  }
+
+  constructor (indexAddress: string, connector: Web3Connector) {
+    this.address = indexAddress;
+    this.connector = connector;
+  }
+
+  async _getDeployedIndex (): Promise<Object> {
+    if (!this.deployedIndex) {
+      this.deployedIndex = await Contracts.getIndexInstance(this.address, this.connector.web3.currentProvider);
+    }
+    return this.deployedIndex;
+  }
+
+  async addHotel (hotelData: HotelDataInterface): Promise<HotelInterface> {
+    try {
+      const hotel = HotelDataProvider.createInstance(this.connector, await this._getDeployedIndex());
+      hotel.setLocalData(hotelData);
+      return hotel.createOnNetwork({
+        from: hotelData.manager,
+        to: this.address,
+      });
+    } catch (err) {
+      // TODO improve error handling
+      throw new Error('Cannot add hotel: ' + err.message);
+    }
+  }
+
+  async updateHotel (hotel: HotelInterface): Promise<HotelInterface> {
+    try {
+      // We need to separate calls to be able to properly catch exceptions
+      const updatedHotel = await hotel.updateOnNetwork({
+        from: await hotel.getManager(),
+        to: this.address,
+      });
+      return updatedHotel;
+    } catch (err) {
+      // TODO improve error handling
+      throw new Error('Cannot update hotel:' + err.message);
+    }
+  }
+
+  async removeHotel (hotel: HotelInterface): Promise<boolean> {
+    try {
+      // We need to separate calls to be able to properly catch exceptions
+      const result = ((hotel: any): HotelDataProvider).removeFromNetwork({ // eslint-disable-line flowtype/no-weak-types
+        from: await hotel.getManager(),
+        to: this.address,
+      });
+      return result;
+    } catch (err) {
+      // TODO improve error handling
+      // invalid opcode -> non-existent hotel
+      // invalid opcode -> failed check for manager
+      throw new Error('Cannot remove hotel: ' + err.message);
+    }
+  }
+
+  async getHotel (address: string): Promise<?HotelInterface> {
+    const index = await this._getDeployedIndex();
+    try {
+      const hotelIndex = await index.hotelsIndex(address);
+      // TODO is this really true? Are we not excluding legal data on zeroth position?
+      if (!hotelIndex || hotelIndex.isZero()) {
+        throw new Error('Not found in hotel list');
+      } else {
+        return HotelDataProvider.createInstance(this.connector, index, address);
+      }
+    } catch (err) {
+      // TODO better error handling
+      throw new Error('Cannot find hotel at ' + address + ': ' + err.message);
+    }
+  }
+
+  async getAllHotels (): Promise<Array<HotelInterface>> {
+    const index = await this._getDeployedIndex();
+    const hotelsAddressList = await index.getHotels();
+    let getHotelDetails = hotelsAddressList
+      // Filtering null addresses beforehand improves efficiency
+      .filter((addr: string): boolean => !Utils.isZeroAddress(addr))
+      .map((addr: string): Promise<?HotelInterface> => {
+        return this.getHotel(addr) // eslint-disable-line promise/no-nesting
+          // We don't really care why the hotel is inaccessible
+          // and we need to catch exceptions here on each individual hotel
+          .catch((err: Error): null => {
+            // TODO optional logging
+            if (err) {}
+            return null;
+          });
+      });
+    const hotelDetails: Array<?HotelInterface> = await (Promise.all(getHotelDetails): any); // eslint-disable-line flowtype/no-weak-types
+    const hotelList: Array<HotelInterface> = (hotelDetails.filter((a: ?HotelInterface): boolean => a != null): any); // eslint-disable-line flowtype/no-weak-types
+    return hotelList;
+  }
+}
+
+export default WTIndexDataProvider;

--- a/src/network/connectors/web3/index.js
+++ b/src/network/connectors/web3/index.js
@@ -1,0 +1,45 @@
+// @flow
+
+import Web3 from 'web3';
+
+import type { ConnectorInterface, WTIndexInterface } from '../../interfaces';
+import WTIndexDataAccessor from '../../data-accessors/wt-index';
+import WTIndexDataProvider from './data-providers/wt-index';
+
+export type Web3ConnectorOptionsType = {
+  // URL of currently used RPC provider
+  provider?: string | Object,
+  // Gas coefficient that is used as a multiplier when setting
+  // a transaction gas
+  // TODO maybe we can set this up later or automagically?
+  gasCoefficient?: number
+};
+
+class Web3Connector implements ConnectorInterface {
+  options: Web3ConnectorOptionsType;
+  web3: Web3;
+
+  static createInstance (options: Web3ConnectorOptionsType): Web3Connector {
+    return new Web3Connector(options);
+  }
+
+  constructor (options: Web3ConnectorOptionsType) {
+    this.options = options;
+    this.options.gasCoefficient = this.options.gasCoefficient || 2;
+    this.web3 = new Web3(options.provider);
+  }
+
+  async getWindingTreeIndex (address: string): Promise<WTIndexInterface> {
+    const providerInstance = await WTIndexDataProvider.createInstance(address, this);
+    return WTIndexDataAccessor.createInstance(providerInstance);
+  }
+
+  // TODO improve or automate
+  applyGasCoefficient (gas: number): number {
+    if (this.options.gasCoefficient) {
+      return Math.ceil(gas * this.options.gasCoefficient);
+    }
+    return gas;
+  }
+};
+export default Web3Connector;

--- a/src/network/connectors/web3/utils.js
+++ b/src/network/connectors/web3/utils.js
@@ -1,0 +1,27 @@
+// @flow
+
+import BigNumber from 'bignumber.js';
+import web3Abi from 'web3-eth-abi';
+
+class Utils {
+  static isZeroAddress (address: string): boolean {
+    if (!address) { return true; }
+    try {
+      const addrAsBn = new BigNumber(address);
+      return addrAsBn.isZero();
+    } catch (e) {
+      return true;
+    }
+  }
+
+  static encodeMethodCall (contractAbi: Object, methodName: string, parameters: Array<mixed>): string {
+    // todo type checking of parameters
+    const methodAbi = contractAbi.filter((n: Object): boolean => n.name === methodName && n.inputs.length === parameters.length).pop();
+    if (!methodAbi) {
+      throw Error('Method not found, maybe you are using an invalid signature?');
+    }
+    return web3Abi.encodeFunctionCall(methodAbi, parameters);
+  }
+}
+
+export default Utils;

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -2,10 +2,13 @@
 
 import { ConnectorInterface, WTIndexInterface } from './interfaces';
 import JsonConnector from './connectors/json';
+import Web3Connector from './connectors/web3';
 import type { JsonConnectorOptionsType } from './connectors/json';
+import type { Web3ConnectorOptionsType } from './connectors/web3';
 
-export type NetworkConnectorType = 'json';
-export type NetworkOptionsType = JsonConnectorOptionsType;
+// Way of connecting to the underlying network. defaults to web3
+export type NetworkConnectorType = 'web3' | 'json';
+export type NetworkOptionsType = JsonConnectorOptionsType & Web3ConnectorOptionsType;
 
 class Network {
   type: string;
@@ -13,7 +16,7 @@ class Network {
   _connector: ConnectorInterface;
 
   static createInstance (connectorType: NetworkConnectorType, options: NetworkOptionsType): Network {
-    if (!['json'].includes(connectorType)) {
+    if (!['web3', 'json'].includes(connectorType)) {
       // TODO improve exception system
       throw new Error('Unrecognized network type');
     }
@@ -30,6 +33,10 @@ class Network {
       switch (this.type) {
       case 'json':
         this._connector = JsonConnector.createInstance(this.options);
+        break;
+      case 'web3':
+      default:
+        this._connector = Web3Connector.createInstance(this.options);
         break;
       }
     }

--- a/src/network/interfaces.js
+++ b/src/network/interfaces.js
@@ -13,23 +13,16 @@ export interface HotelDataInterface extends Object {
   name?: ?string;
   description?: ?string;
   manager?: ?string
-  /* lineOne: ?string;
-  lineTwo: ?string;
-  zip: ?string;
-  country: ?string;
-  created: ?Date;
-  timezone: ?string;
-  latitude: ?number;
-  longitude: ?number */
 }
 
 export interface HotelInterface {
-  getAddress(): Promise<?string>;
-  getName(): Promise<?string>;
-  getDescription(): Promise<?string>;
-  getManager(): Promise<?string>;
-  // experimental
-  updateOnNetwork (transactionOptions: Object): Promise<HotelInterface>
+  address: Promise<?string>;
+  name: Promise<?string>;
+  description: Promise<?string>;
+  manager: Promise<?string>;
+  createOnNetwork (transactionOptions: Object): Promise<HotelInterface>;
+  updateOnNetwork (transactionOptions: Object): Promise<HotelInterface>;
+  removeFromNetwork (transactionOptions: Object): Promise<boolean>
 }
 
 export interface WTIndexInterface {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -33,11 +33,11 @@ describe('WTLibs', () => {
       assert.isDefined(createNetworkSpy.firstCall.args[1].random);
     });
 
-    it('should fallback to json network if networkConnectorType is not specified', () => {
+    it('should fallback to web3 network if networkConnectorType is not specified', () => {
       const libs = WTLibs.createInstance();
       assert.isDefined(libs.network);
       assert.equal(createNetworkSpy.callCount, 1);
-      assert.equal(createNetworkSpy.firstCall.args[0], 'json');
+      assert.equal(createNetworkSpy.firstCall.args[0], 'web3');
     });
   });
 });

--- a/test/network/connectors/json.spec.js
+++ b/test/network/connectors/json.spec.js
@@ -56,43 +56,16 @@ describe('WTLibs.network.connectors.json', () => {
         assert.isDefined(index.dataProvider.source.index);
         assert.isDefined(index.dataProvider.source.index.hotels);
       });
-
-      it('should initialize async data accessors', async () => {
-        const address = '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769';
-        const myDataSource = getFreshDataSource();
-        assert.isUndefined(myDataSource.fullIndex.index.hotels[address].getAddress);
-        const myConnector = JsonConnector.createInstance({ source: myDataSource });
-        const myIndex = await myConnector.getWindingTreeIndex('fullIndex');
-        assert.isDefined(myIndex.dataProvider);
-        assert.isDefined(myIndex.dataProvider.source.index);
-        assert.isDefined(myIndex.dataProvider.source.index.hotels[address].getAddress);
-      });
-
-      it('should not initialize async data accessors if they are already there', async () => {
-        const address = '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769';
-        const myDataSource = getFreshDataSource();
-        const enhancedHotel = Object.assign(myDataSource.fullIndex.index.hotels[address], {
-          getAddress: async () => myDataSource.fullIndex.index.hotels[address].address,
-          getName: async () => myDataSource.fullIndex.index.hotels[address].name,
-          getDescription: async () => myDataSource.fullIndex.index.hotels[address].description,
-          getManager: async () => myDataSource.fullIndex.index.hotels[address].manager,
-        });
-        const myConnector = JsonConnector.createInstance({ source: myDataSource });
-        const myIndex = await myConnector.getWindingTreeIndex('fullIndex');
-        assert.isDefined(myIndex.dataProvider);
-        assert.isDefined(myIndex.dataProvider.source.index);
-        assert.equal(myIndex.dataProvider.source.index.hotels[address].getAddress, enhancedHotel.getAddress);
-      });
     });
 
     describe('addHotel', () => {
       it('should add hotel', async () => {
         const hotel = await index.addHotel({ name: 'a', description: 'b' });
         assert.isDefined(hotel);
-        assert.equal(await hotel.getName(), 'a');
-        assert.equal(await hotel.getDescription(), 'b');
+        assert.equal(await hotel.name, 'a');
+        assert.equal(await hotel.description, 'b');
         assert.isDefined(index.dataProvider.source.index.hotels);
-        assert.isDefined(index.dataProvider.source.index.hotels[await hotel.getAddress()]);
+        assert.isDefined(index.dataProvider.source.index.hotels[await hotel.address]);
       });
     });
 
@@ -102,10 +75,10 @@ describe('WTLibs.network.connectors.json', () => {
         const hotel = await index.getHotel(address);
         assert.isDefined(hotel);
         assert.isDefined(index.dataProvider.source.index.hotels);
-        assert.equal(await hotel.getAddress(), address);
-        assert.equal(await hotel.getName(), index.dataProvider.source.index.hotels[address].name);
-        assert.equal(await hotel.getDescription(), index.dataProvider.source.index.hotels[address].description);
-        assert.equal(await hotel.getManager(), index.dataProvider.source.index.hotels[address].manager);
+        assert.equal(await hotel.address, address);
+        assert.equal(await hotel.name, index.dataProvider.source.index.hotels[address].name);
+        assert.equal(await hotel.description, index.dataProvider.source.index.hotels[address].description);
+        assert.equal(await hotel.manager, index.dataProvider.source.index.hotels[address].manager);
       });
 
       it('should throw when hotel does not exist', async () => {
@@ -119,15 +92,15 @@ describe('WTLibs.network.connectors.json', () => {
 
       it('should get added hotel', async () => {
         const hotel = await index.addHotel({ name: 'Third one', description: '3' });
-        assert.isDefined(await hotel.getName(), 'Third one');
+        assert.isDefined(await hotel.name, 'Third one');
         assert.isDefined(index.dataProvider.source.index.hotels);
-        assert.isDefined(index.dataProvider.source.index.hotels[await hotel.getAddress()]);
-        const hotel2 = await index.getHotel(await hotel.getAddress());
+        assert.isDefined(index.dataProvider.source.index.hotels[await hotel.address]);
+        const hotel2 = await index.getHotel(await hotel.address);
         assert.isDefined(hotel2);
-        assert.equal(await hotel2.getAddress(), await hotel.getAddress());
-        assert.equal(await hotel2.getName(), await hotel.getName());
-        assert.equal(await hotel2.getDescription(), await hotel.getDescription());
-        assert.equal(await hotel2.getManager(), await hotel.getManager());
+        assert.equal(await hotel2.address, await hotel.address);
+        assert.equal(await hotel2.name, await hotel.name);
+        assert.equal(await hotel2.description, await hotel.description);
+        assert.equal(await hotel2.manager, await hotel.manager);
       });
     });
 
@@ -137,7 +110,7 @@ describe('WTLibs.network.connectors.json', () => {
         const fakeAddress = '0x96eA4BbF71FEa3c9411C1Cefc555E9d7189695fA';
         try {
           const hotel = _.cloneDeep(await index.getHotel(address));
-          hotel.getAddress = async () => fakeAddress;
+          hotel.address = fakeAddress;
           await index.removeHotel(hotel);
           throw new Error('should not have been called');
         } catch (e) {
@@ -150,7 +123,7 @@ describe('WTLibs.network.connectors.json', () => {
         const address = '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769';
         try {
           const hotel = _.cloneDeep(await index.getHotel(address));
-          hotel.getManager = async () => manager;
+          hotel.manager = manager;
           await index.removeHotel(hotel);
           throw new Error('should not have been called');
         } catch (e) {
@@ -161,7 +134,7 @@ describe('WTLibs.network.connectors.json', () => {
         const address = '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769';
         try {
           const hotel = _.cloneDeep(await index.getHotel(address));
-          hotel.getAddress = async () => null;
+          hotel.address = null;
           await index.removeHotel(hotel);
           throw new Error('should not have been called');
         } catch (e) {

--- a/test/network/connectors/web3/data-providers.spec.js
+++ b/test/network/connectors/web3/data-providers.spec.js
@@ -1,0 +1,172 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import WTIndexDataProvider from '../../../../src/network/connectors/web3/data-providers/wt-index';
+import HotelDataProvider from '../../../../src/network/connectors/web3/data-providers/hotel';
+import Web3Connector from '../../../../src/network/connectors/web3';
+import testedNetwork from '../../../utils/network-definition';
+import Contracts from '../../../../src/network/connectors/web3/contracts';
+
+describe('WTLibs.network.connectors.web3.data-providers', () => {
+  let connector, indexDataProvider;
+
+  beforeEach(async function () {
+    if (process.env.TESTED_NETWORK !== 'web3') {
+      this.skip();
+    }
+    connector = Web3Connector.createInstance(testedNetwork.withDataSource().networkOptions);
+    indexDataProvider = await WTIndexDataProvider.createInstance(testedNetwork.indexAddress, connector);
+  });
+
+  describe('WTIndexDataProvider', () => {
+    it('should throw when we want index from a bad address', async () => {
+      const customIndexDataProvider = await WTIndexDataProvider.createInstance('0x96eA4BbF71FEa3c9411C1Cefc555E9d7189695fA', connector);
+      try {
+        await customIndexDataProvider._getDeployedIndex();
+        throw new Error('should not have been called');
+      } catch (e) {
+        assert.match(e.message, /cannot get index instance/i);
+      }
+    });
+
+    describe('getHotel', () => {
+      it('should throw if address is malformed', async () => {
+        try {
+          await indexDataProvider.getHotel('random-address');
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /cannot find hotel/i);
+        }
+      });
+
+      it('should throw if no hotel exists on that address', async () => {
+        try {
+          await indexDataProvider.getHotel('0x96eA4BbF71FEa3c9411C1Cefc555E9d7189695fA');
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /cannot find hotel/i);
+        }
+      });
+
+      it('should throw if hotel cannot be added due to network issues', async () => {
+        const myIndexDataProvider = await WTIndexDataProvider.createInstance('some-other-address', connector);
+        try {
+          await myIndexDataProvider.addHotel({ name: 'a', description: 'b' });
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /cannot add hotel/i);
+        }
+      });
+    });
+  });
+
+  describe('Hotel', () => {
+    describe('_getDeployedHotel', () => {
+      let getHotelContractSpy;
+      beforeEach(function () {
+        if (process.env.TESTED_NETWORK !== 'web3') {
+          this.skip();
+        }
+        getHotelContractSpy = sinon.spy(Contracts, 'getHotelInstance');
+      });
+
+      afterEach(() => {
+        Contracts.getHotelInstance.restore();
+      });
+
+      it('should throw when we want hotel from a bad address', async () => {
+        try {
+          const hotelProvider = HotelDataProvider.createInstance(connector, await indexDataProvider._getDeployedIndex(), '0x96eA4BbF71FEa3c9411C1Cefc555E9d7189695fA');
+          await hotelProvider._getDeployedHotel();
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /cannot get hotel instance/i);
+        }
+      });
+
+      it('should throw when we want hotel without an address', async () => {
+        try {
+          const hotelProvider = HotelDataProvider.createInstance(connector, await indexDataProvider._getDeployedIndex());
+          await hotelProvider._getDeployedHotel();
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /cannot get hotel instance/i);
+        }
+      });
+
+      it('should throw if we try to get data from network in a hotel without address', async () => {
+        try {
+          const hotelProvider = HotelDataProvider.createInstance(connector, await indexDataProvider._getDeployedIndex());
+          await hotelProvider._loadFromNetwork();
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /cannot call hotel/i);
+        }
+      });
+
+      it('should cache contract instances', async () => {
+        const hotelProvider = HotelDataProvider.createInstance(connector, await indexDataProvider._getDeployedIndex(), '0x4a763f50dfe5cf4468b4171539e021a26fcee0cc');
+        assert.equal(getHotelContractSpy.callCount, 0);
+        await hotelProvider._getDeployedHotel();
+        assert.equal(getHotelContractSpy.callCount, 1);
+        await hotelProvider._getDeployedHotel();
+        assert.equal(getHotelContractSpy.callCount, 1);
+      });
+    });
+
+    describe('data getters', () => {
+      it('should fetch data from network only after the getter is accessed', async () => {
+        const hotelProvider = HotelDataProvider.createInstance(connector, await indexDataProvider._getDeployedIndex(), '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769');
+        sinon.spy(hotelProvider, '_loadFromNetwork');
+        assert.equal(hotelProvider._loadFromNetwork.callCount, 0);
+        assert.equal(await hotelProvider.getName(), 'First hotel');
+        assert.equal(hotelProvider._loadFromNetwork.callCount, 1);
+        assert.equal(await hotelProvider.getManager(), '0x87265a62c60247f862b9149423061b36b460f4bb');
+        assert.equal(hotelProvider._loadFromNetwork.callCount, 1);
+      });
+    });
+
+    describe('data setters', () => {
+      it('should not mark object dirty if data does not change', async () => {
+        const hotelProvider = HotelDataProvider.createInstance(connector, await indexDataProvider._getDeployedIndex(), '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769');
+        assert.equal(hotelProvider.state, 'fresh');
+        const currentName = await hotelProvider.getName();
+        assert.equal(hotelProvider.state, 'synced');
+        hotelProvider.name = currentName;
+        assert.equal(hotelProvider.state, 'synced');
+        hotelProvider.name = 'Changed name';
+        assert.equal(hotelProvider.state, 'dirty');
+      });
+    });
+
+    describe('write to network', () => {
+      // it should not update when data is not changed
+      it('should update', async () => {
+        const hotelProvider = HotelDataProvider.createInstance(connector, await indexDataProvider._getDeployedIndex(), '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769');
+        
+        // TODO loadFromNetwork should happen automatically before write back to network, not by getName
+        const oldName = await hotelProvider.getName();
+        const newName = 'Random changed name';
+        hotelProvider.name = newName;
+        await hotelProvider.updateOnNetwork({
+          from: await hotelProvider.getManager(),
+          to: indexDataProvider.address,
+        });
+        assert.equal(await hotelProvider.getName(), newName);
+        // Force reload from network
+        await hotelProvider._loadFromNetwork();
+        assert.equal(await hotelProvider.getName(), newName);
+
+        // And change this back to keep data consistent for other tests
+        hotelProvider.name = oldName;
+        await hotelProvider.updateOnNetwork({
+          from: await hotelProvider.getManager(),
+          to: indexDataProvider.address,
+        });
+        assert.equal(await hotelProvider.getName(), oldName);
+        // Force reload from network
+        await hotelProvider._loadFromNetwork();
+        assert.equal(await hotelProvider.getName(), oldName);
+      });
+    });
+  });
+});

--- a/test/network/connectors/web3/index.spec.js
+++ b/test/network/connectors/web3/index.spec.js
@@ -1,0 +1,43 @@
+import { assert } from 'chai';
+import Web3Connector from '../../../../src/network/connectors/web3';
+import Utils from '../../../../src/network/connectors/web3/utils';
+import testedNetwork from '../../../utils/network-definition';
+
+describe('WTLibs.network.connectors.web3', () => {
+  describe('Connector', () => {
+    let connector;
+
+    beforeEach(async function () {
+      if (process.env.TESTED_NETWORK !== 'web3') {
+        this.skip();
+      }
+      connector = Web3Connector.createInstance(testedNetwork.withDataSource().networkOptions);
+    });
+
+    describe('applyGasCoefficient', () => {
+      it('should apply gas coefficient', () => {
+        const gas = connector.applyGasCoefficient(10);
+        assert.equal(gas, 10 * connector.options.gasCoefficient);
+      });
+
+      it('should fallback to gas if no coefficient is specified', () => {
+        const origCoeff = connector.options.gasCoefficient;
+        connector.options.gasCoefficient = undefined;
+        const gas = connector.applyGasCoefficient(10);
+        assert.equal(gas, 10);
+        connector.options.gasCoefficient = origCoeff;
+      });
+    });
+  });
+
+  describe('Utils', () => {
+    describe('_isZeroAddress', () => {
+      it('should behave as expected', () => {
+        assert.equal(Utils.isZeroAddress(), true);
+        assert.equal(Utils.isZeroAddress('random-address'), true);
+        assert.equal(Utils.isZeroAddress('0x0000000000000000000000000000000000000000'), true);
+        assert.equal(Utils.isZeroAddress('0x96eA4BbF71FEa3c9411C1Cefc555E9d7189695fA'), false);
+      });
+    });
+  });
+});

--- a/test/network/connectors/web3/index.spec.js
+++ b/test/network/connectors/web3/index.spec.js
@@ -1,6 +1,8 @@
 import { assert } from 'chai';
+import sinon from 'sinon';
 import Web3Connector from '../../../../src/network/connectors/web3';
 import Utils from '../../../../src/network/connectors/web3/utils';
+import BackedByBlockchain from '../../../../src/network/connectors/web3/backed-by-blockchain';
 import testedNetwork from '../../../utils/network-definition';
 
 describe('WTLibs.network.connectors.web3', () => {
@@ -37,6 +39,68 @@ describe('WTLibs.network.connectors.web3', () => {
         assert.equal(Utils.isZeroAddress('random-address'), true);
         assert.equal(Utils.isZeroAddress('0x0000000000000000000000000000000000000000'), true);
         assert.equal(Utils.isZeroAddress('0x96eA4BbF71FEa3c9411C1Cefc555E9d7189695fA'), false);
+      });
+    });
+  });
+
+  describe('BackedByBlockchain', () => {
+    let bbbInstance;
+    beforeEach(() => {
+      bbbInstance = new BackedByBlockchain();
+      bbbInstance.address = 'aaaa';
+      bbbInstance._getContractInstance = sinon.stub();
+      bbbInstance.setOptions({
+        fields: {
+          randomField: {
+            networkGetter: async () => {
+              return 'field name';
+            },
+            networkSetter: async () => {
+              // pass
+            },
+          },
+        },
+      });
+    });
+    describe('obsolete state', () => {
+      it('should not allow getting when object is in obsolete state', async () => {
+        try {
+          bbbInstance.markObsolete();
+          assert.equal(await bbbInstance.randomField, 'field name');
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /object was destroyed/i);
+        }
+      });
+
+      it('should not allow setting when object is in obsolete state', () => {
+        bbbInstance.markObsolete();
+        try {
+          bbbInstance.randomField = 'something';
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /object was destroyed/i);
+        }
+      });
+    });
+
+    describe('abstract operations', () => {
+      it('should not allow createOnNetwork', async () => {
+        try {
+          await bbbInstance.createOnNetwork();
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /implemented in a subclass/i);
+        }
+      });
+
+      it('should not allow removeFromNetwork', async () => {
+        try {
+          await bbbInstance.removeFromNetwork();
+          throw new Error('should not have been called');
+        } catch (e) {
+          assert.match(e.message, /implemented in a subclass/i);
+        }
       });
     });
   });

--- a/test/usage.spec.js
+++ b/test/usage.spec.js
@@ -66,12 +66,11 @@ describe('WTLibs usage', () => {
       let list = (await index.getAllHotels());
       assert.equal(list.length, 3);
       assert.include(await Promise.all(list.map(async (a) => a.getAddress())), await hotel.getAddress());
-
       const result = await index.removeHotel(hotel);
       assert.equal(result, true);
       list = await index.getAllHotels();
       assert.equal(list.length, 2);
-      assert.notInclude(list.map((a) => a.getAddress()), await hotel.getAddress());
+      assert.notInclude(await Promise.all(list.map(async (a) => a.getAddress())), await hotel.getAddress());
     });
   });
 

--- a/test/usage.spec.js
+++ b/test/usage.spec.js
@@ -20,9 +20,9 @@ describe('WTLibs usage', () => {
         // TODO test location adding as well
       });
       assert.isDefined(hotel);
-      assert.equal(await hotel.getName(), 'new hotel');
-      assert.equal(await hotel.getDescription(), 'some description');
-      assert.equal(await hotel.getManager(), '0xd39ca7d186a37bb6bf48ae8abfeb4c687dc8f906');
+      assert.equal(await hotel.name, 'new hotel');
+      assert.equal(await hotel.description, 'some description');
+      assert.equal(await hotel.manager, '0xd39ca7d186a37bb6bf48ae8abfeb4c687dc8f906');
       // We're removing the hotel to ensure clean slate after this test is run.
       // It is too expensive to re-set on-chain WTIndex after each test.
       const result = await index.removeHotel(hotel);
@@ -62,15 +62,16 @@ describe('WTLibs usage', () => {
         description: 'some desc',
         manager: manager,
       });
-      assert.isDefined(await hotel.getAddress());
+      assert.isDefined(await hotel.address);
       let list = (await index.getAllHotels());
       assert.equal(list.length, 3);
-      assert.include(await Promise.all(list.map(async (a) => a.getAddress())), await hotel.getAddress());
+      assert.include(await Promise.all(list.map(async (a) => a.address)), await hotel.address);
+
       const result = await index.removeHotel(hotel);
       assert.equal(result, true);
       list = await index.getAllHotels();
       assert.equal(list.length, 2);
-      assert.notInclude(await Promise.all(list.map(async (a) => a.getAddress())), await hotel.getAddress());
+      assert.notInclude(list.map(async (a) => a.address), await hotel.address);
     });
   });
 
@@ -79,8 +80,8 @@ describe('WTLibs usage', () => {
       const address = '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769';
       const hotel = await index.getHotel(address);
       assert.isNotNull(hotel);
-      assert.equal(await hotel.getName(), 'First hotel');
-      assert.equal(await hotel.getAddress(), address);
+      assert.equal(await hotel.name, 'First hotel');
+      assert.equal(await hotel.address, address);
     });
 
     it('should throw if no hotel is found on given address', async () => {
@@ -97,15 +98,19 @@ describe('WTLibs usage', () => {
     const hotelAddress = '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769';
     it('should update hotel', async () => {
       const newName = 'Great new hotel name';
+      const newDescription = 'Great new hotel description';
       const hotel = await index.getHotel(hotelAddress);
-      const oldName = await hotel.getName();
+      const oldName = await hotel.name;
+      const oldDescription = await hotel.description;
       hotel.name = newName;
+      hotel.description = newDescription;
       const updatedHotel = await index.updateHotel(hotel);
-      assert.equal(await updatedHotel.getName(), newName);
+      assert.equal(await updatedHotel.name, newName);
       // Change it back to keep data in line
       hotel.name = oldName;
+      hotel.description = oldDescription;
       const updatedHotel2 = await index.updateHotel(hotel);
-      assert.equal(await updatedHotel2.getName(), oldName);
+      assert.equal(await updatedHotel2.name, oldName);
     });
 
     it('should throw if hotel has no address', async () => {

--- a/test/utils/contracts/Migrations.sol
+++ b/test/utils/contracts/Migrations.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.4.18;
+
+contract Migrations {
+  address public owner;
+
+  // A function with the signature `last_completed_migration()`, returning a uint, is required.
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function Migrations() {
+    owner = msg.sender;
+  }
+
+  // A function with the signature `setCompleted(uint)` is required.
+  function setCompleted(uint completed) restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/test/utils/migrations/1_initial_migration.js
+++ b/test/utils/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require('./Migrations.sol');
+
+module.exports = function (deployer) {
+  deployer.deploy(Migrations);
+};

--- a/test/utils/migrations/2_deploy_contracts.js
+++ b/test/utils/migrations/2_deploy_contracts.js
@@ -1,0 +1,66 @@
+const TruffleContract = require('truffle-contract');
+const Web3 = require('web3');
+const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+
+// dirty hack for web3@1.0.0 support for localhost testrpc, see
+// https://github.com/trufflesuite/truffle-contract/issues/56#issuecomment-331084530
+function hackInSendAsync (instance) {
+  if (typeof instance.currentProvider.sendAsync !== 'function') {
+    instance.currentProvider.sendAsync = function () {
+      return instance.currentProvider.send.apply(
+        instance.currentProvider, arguments
+      );
+    };
+  }
+  return instance;
+}
+
+function getContractWithProvider (metadata, provider) {
+  let contract = new TruffleContract(metadata);
+  contract.setProvider(provider);
+  contract = hackInSendAsync(contract);
+  return contract;
+}
+
+const LifTokenTest = getContractWithProvider(require('@windingtree/lif-token/build/contracts/LifTokenTest'), provider);
+const WTIndex = getContractWithProvider(require('@windingtree/wt-contracts/build/contracts/WTIndex'), provider);
+
+module.exports = function (deployer, network, accounts) {
+  if (network === 'development') {
+    let firstIndex, secondIndex,
+      firstIndexAddress, secondIndexAddress;
+    // First, we need the token contract with a faucet
+    return deployer.deploy(LifTokenTest, { from: accounts[0], gas: 60000000 })
+      .then(function () {
+        // And then we setup the WTIndex
+        return deployer.deploy(WTIndex, { from: accounts[0], gas: 60000000 });
+      }).then(function () {
+        firstIndexAddress = WTIndex.address;
+        firstIndex = WTIndex.at(firstIndexAddress);
+        return firstIndex.setLifToken(LifTokenTest.address, { from: accounts[0], gas: 60000000 });
+      }).then(function (a) {
+        return deployer.deploy(WTIndex, { from: accounts[0], gas: 60000000 });
+      }).then(function () {
+        secondIndexAddress = WTIndex.address;
+        secondIndex = WTIndex.at(secondIndexAddress);
+        return secondIndex.setLifToken(LifTokenTest.address, { from: accounts[0], gas: 60000000 });
+      }).then(function () {
+        return Promise.all([
+          firstIndex.registerHotel('First hotel', 'first description', { from: accounts[0], gas: 60000000 }),
+          firstIndex.registerHotel('Second hotel', 'second description', { from: accounts[0], gas: 60000000 }),
+        ]);
+      }).then(function () {
+        return firstIndex.getHotels();
+      }).then(function (hotels) {
+        console.log('========================================');
+        console.log('    Index and token owner:', accounts[0]);
+        console.log('    Wallet account:', accounts[1]);
+        console.log('    LifToken with faucet:', LifTokenTest.address);
+        console.log('    WTIndex:', firstIndexAddress);
+        console.log('    Second WTIndex:', secondIndexAddress);
+        console.log('    First hotel', hotels[1]);
+        console.log('    Second hotel', hotels[2]);
+        return true;
+      });
+  }
+};

--- a/test/utils/network-definition.js
+++ b/test/utils/network-definition.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import dataSource from './data/network.json';
 import JsonConnector from '../../src/network/connectors/json';
+import Web3Connector from '../../src/network/connectors/web3';
 
 export const JsonNetwork = {
   type: 'json',
@@ -16,4 +17,23 @@ export const JsonNetwork = {
   emptyIndexAddress: 'emptyIndex',
 };
 
-export default JsonNetwork;
+export const Web3Network = {
+  type: 'web3',
+  connector: Web3Connector,
+  emptyConfig: {},
+  withDataSource: () => ({
+    networkConnectorType: 'web3',
+    networkOptions: { provider: 'http://localhost:8545' },
+  }),
+  indexAddress: '0x8c2373842d5ea4ce4baf53f4175e5e42a364c59c',
+  emptyIndexAddress: '0x994afd347b160be3973b41f0a144819496d175e9',
+};
+
+let chosenNetwork;
+
+if (process.env.TESTED_NETWORK === 'web3') {
+  chosenNetwork = Web3Network;
+} else {
+  chosenNetwork = JsonNetwork;
+}
+export default chosenNetwork;

--- a/test/utils/scripts/localtestnet.sh
+++ b/test/utils/scripts/localtestnet.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -o errexit
+
+# Executes cleanup function at script exit.
+trap cleanup EXIT
+
+cleanup() {
+  # Kill the testrpc instance that we started (if we started one and if it's still running).
+  if [ -n "$testrpc_pid" ] && ps -p $testrpc_pid > /dev/null; then
+    kill -9 $testrpc_pid
+  fi
+  # Kill the npm instance that we started (if we started one and if it's still running).
+  if [ -n "$npm_pid" ] && ps -p $npm_pid > /dev/null; then
+    kill -9 $npm_pid
+  fi  
+}
+
+testrpc_port=8545
+
+testrpc_running() {
+  nc -z localhost "$testrpc_port"
+}
+
+start_testrpc() {
+  # We define 10 accounts with balance lots of ether, needed for high-value tests.
+  local accounts=(
+    --account="0xe8280389ca1303a2712a874707fdd5d8ae0437fab9918f845d26fd9919af5a92,10000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    --account="0xed095a912033d26dc444d2675b33414f0561af170d58c33f394db8812c87a764,10000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    --account="0xf5556ca108835f04cd7d29b4ac66f139dc12b61396b147674631ce25e6e80b9b,10000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    --account="0xd1bea55dd05b35be047e409617bc6010b0363f22893b871ceef2adf8e97b9eb9,10000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    --account="0xfc452929dc8ffd956ebab936ed0f56d71a8c537b0393ea9da4807836942045c5,10000000000000000000000000000000000000000000000000000000000000000000000000000000"
+  )
+
+  node_modules/.bin/ganache-cli  --gasLimit 0xfffffffffff "${accounts[@]}" > /dev/null &
+  testrpc_pid=$!
+}
+
+if testrpc_running; then
+  echo "Using existing testrpc instance"
+else
+  echo "Starting our own testrpc instance"
+  start_testrpc
+fi
+
+# migrate contracts
+./node_modules/.bin/truffle migrate --network development
+# Fire up the application
+TESTED_NETWORK=web3 npm run test-runner &
+npm_pid=$!
+# And let testrpc running
+wait $npm_pid

--- a/truffle.js
+++ b/truffle.js
@@ -1,0 +1,20 @@
+require('babel-register');
+require('babel-polyfill');
+
+module.exports = {
+  contracts_directory: './test/utils/contracts',
+  migrations_directory: './test/utils/migrations',
+  networks: {
+    development: {
+      host: 'localhost',
+      port: 8545,
+      network_id: '77'
+    }
+  },
+  solc: {
+    optimizer: {
+      enabled: true,
+      runs: 200
+    }
+  }
+};


### PR DESCRIPTION
Part of #120. I know it's big, but I think it's not possible to split it anymore.

Basically, this is an implementation of the public interface introduced in #119 backed by a local web3 network. There are lots of `TODO` comments, I'm very well aware of many shortcomings of this version.

The juicy stuff is happening in `src/network/connectors/web3/data-providers`. `wt-index.js` provides the actual implementation of public interface, and the `hotel.js` is trying to be both data storage and an encapsulation for data manipulation on the actual network. It's not ideal and I'm tackling that coupling next.

From now on, the PRs should be much smaller increments. It's however still possible, that some public facing interface will change. I'm going to be experimenting with some meta `getters` and `setters` (see [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) or [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy)) a lot. One of my main goals is to implement a kind of smart lazy loading to achieve a reasonable performance.