### PR TITLE
breaking: Renames accessor to adapter everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,21 @@ under the hood.
 // You need to deploy the index and the hotel first. See test/utils/migrations
 // for inspiration.
 import WTLibs from '@windingtree/wt-js-libs';
-import InMemoryAccessor from '@windingtree/off-chain-accessor-in-memory';
+import InMemoryAdapter from '@windingtree/off-chain-adapter-in-memory';
 
 const libs = WTLibs.createInstance({
   dataModelOptions: {
     provider: 'http://localhost:8545',
   },
   offChainDataOptions: {
-    accessors: {
-      // This is how you plug-in any off-chain data accessor you want.
+    adapters: {
+      // This is how you plug-in any off-chain data adapter you want.
       json: {
         options: {
           // some: options
         }
         create: (options) => {
-          return new InMemoryAccessor(options);
+          return new InMemoryAdapter(options);
         },
       },
     },
@@ -56,24 +56,24 @@ const hotelName = await hotelDescription.contents.name;
 
 The current documentation can be rendered by running `npm run docs`
 
-### Off-chain data accessors
+### Off-chain data adapters
 
 **Existing implementations**
 
-- [In memory](https://github.com/windingtree/off-chain-accessor-in-memory) - Example basic implementation which is not very useful, but should be enough for quick hacking or testing
+- [In memory](https://github.com/windingtree/off-chain-adapter-in-memory) - Example basic implementation which is not very useful, but should be enough for quick hacking or testing
 
-#### Developing your own off-chain data accessor
+#### Developing your own off-chain data adapter
 
-For insipiration, you can have a look at [in-memory accessor](https://github.com/windingtree/off-chain-accessor-in-memory),
+For insipiration, you can have a look at [in-memory adapter](https://github.com/windingtree/off-chain-adapter-in-memory),
 if you'd like to create it all by yourself, here's what you need.
 
-1. Your package has to implement a [simple interface](https://github.com/windingtree/wt-js-libs/blob/proposal/next/docs/reference.md#offchaindataaccessorinterface)
+1. Your package has to implement a [simple interface](https://github.com/windingtree/wt-js-libs/blob/proposal/next/docs/reference.md#offchaindataadapterinterface)
 that provides ways to store, update and retrieve data.
 1. You can also choose how your plugin is instantiated and whether you need any initialization
 options. These will be passed whenever an instance is created.
-1. Off Chain data accessors are used in two places
-    1. `StoragePointer` - The accessor is used to download off-chain data in there
-    1. `OffChainDataClient` - It is responsible for proper instantiation of all off-chain data accessors.
+1. Off Chain data adapters are used in two places
+    1. `StoragePointer` - The adapter is used to download off-chain data in there
+    1. `OffChainDataClient` - It is responsible for proper instantiation of all off-chain data adapters.
 
 The interface is subject to change as we go along and find out what other types
 of storages might require - be it a signature verification, data signing and other non-common

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -47,7 +47,7 @@
 -   [TransactionOptionsInterface][43]
 -   [HotelInterface][44]
 -   [WTIndexInterface][45]
--   [OffChainDataAccessorInterface][46]
+-   [OffChainDataAdapterInterface][46]
 -   [DataModelInterface][47]
 -   [RawLogRecordInterface][48]
 -   [DecodedLogRecordInterface][49]
@@ -62,7 +62,7 @@
 -   [OffChainDataClient][58]
     -   [setup][59]
     -   [\_\_reset][60]
-    -   [getAccessor][61]
+    -   [getAdapter][61]
 -   [RemotelyBackedDataset][62]
     -   [bindProperties][63]
     -   [isObsolete][64]
@@ -628,6 +628,10 @@ about every hotel.
 Ethereum transaction options that are passed from an external user.
 It has to contain `from` and usually would contain `to` as well.
 
+This copies the structure of [https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#contract-estimategas][130]
+as it might be used as a base for gas estimation prior to actually
+sending a transaction.
+
 **Properties**
 
 -   `from` **[string][98]** 
@@ -666,7 +670,7 @@ necessary for interaction with the hotels.\`
 -   `updateHotel` **function (wallet: [WalletInterface][120], hotel: [HotelInterface][124]): [Promise][106]&lt;[Array][101]&lt;[string][98]>>** 
 -   `removeHotel` **function (wallet: [WalletInterface][120], hotel: [HotelInterface][124]): [Promise][106]&lt;[Array][101]&lt;[string][98]>>** 
 
-## OffChainDataAccessorInterface
+## OffChainDataAdapterInterface
 
 Interface for an off-chain storage read.
 
@@ -718,7 +722,7 @@ and act upon.
 ## TransactionDataInterface
 
 Ethereum transaction data used when creating transaction, see for example
-[https://web3js.readthedocs.io/en/1.0/web3-eth-accounts.html#signtransaction][130]
+[https://web3js.readthedocs.io/en/1.0/web3-eth-accounts.html#signtransaction][131]
 
 **Properties**
 
@@ -734,7 +738,7 @@ Ethereum transaction data used when creating transaction, see for example
 ## TxInterface
 
 Ethereum transaction data after TX was accepted by the network, see
-for example [http://web3js.readthedocs.io/en/1.0/web3-eth.html#gettransaction][131]
+for example [http://web3js.readthedocs.io/en/1.0/web3-eth.html#gettransaction][132]
 
 **Properties**
 
@@ -780,7 +784,7 @@ about the transaction status, its age and decoded logs.
 -   `transactionHash` **[string][98]** 
 -   `blockAge` **[number][105]** 
 -   `decodedLogs` **[Array][101]&lt;[DecodedLogRecordInterface][103]>** 
--   `raw` **[TxReceiptInterface][132]** 
+-   `raw` **[TxReceiptInterface][133]** 
 
 ## AdaptedTxResultsInterface
 
@@ -791,12 +795,12 @@ assumptions about confirmations). This also contains the raw data.
 
 **Properties**
 
--   `meta` **{total: [number][105], processed: [number][105], minBlockAge: [number][105], maxBlockAge: [number][105], allPassed: [boolean][133]}** 
+-   `meta` **{total: [number][105], processed: [number][105], minBlockAge: [number][105], maxBlockAge: [number][105], allPassed: [boolean][134]}** 
 -   `meta.total` **[number][105]** 
 -   `meta.processed` **[number][105]** 
 -   `meta.minBlockAge` **[number][105]** 
 -   `meta.maxBlockAge` **[number][105]** 
--   `meta.allPassed` **[boolean][133]** 
+-   `meta.allPassed` **[boolean][134]** 
 -   `results` **{}?** 
 
 ## WalletInterface
@@ -814,7 +818,7 @@ Wallet abstraction interface. It assumes the following workflow:
 **Properties**
 
 -   `unlock` **function (password: [string][98]): void** 
--   `signAndSendTransaction` **function (transactionData: [TransactionDataInterface][134], onReceipt: function (receipt: [TxReceiptInterface][132]): void?): [Promise][106]&lt;[string][98]>** 
+-   `signAndSendTransaction` **function (transactionData: [TransactionDataInterface][135], onReceipt: function (receipt: [TxReceiptInterface][133]): void?): [Promise][106]&lt;[string][98]>** 
 -   `lock` **function (): void** 
 -   `destroy` **function (): void** 
 -   `getAddress` **function (): [string][98]** 
@@ -823,9 +827,9 @@ Wallet abstraction interface. It assumes the following workflow:
 
 Interface for Ethereum keystore
 
-Description: [https://medium.com/@julien.m./what-is-an-ethereum-keystore-file-86c8c5917b97][135]
+Description: [https://medium.com/@julien.m./what-is-an-ethereum-keystore-file-86c8c5917b97][136]
 
-Specification: [https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition][136]
+Specification: [https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition][137]
 
 **Properties**
 
@@ -850,24 +854,24 @@ Specification: [https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Defini
 
 OffChainDataClientOptionsType
 
-Type: {accessors: {}}
+Type: {adapters: {}}
 
 **Properties**
 
--   `accessors` **{}** 
+-   `adapters` **{}** 
 
 ## OffChainDataClient
 
 OffChainDataClient is a static factory class that is responsible
-for creating proper instances of OffChainDataAccessorInterface.
+for creating proper instances of OffChainDataAdapterInterface.
 It is configured during the library initialization.
 
-Please bear in mind, that once the accessors are configured, the
+Please bear in mind, that once the adapters are configured, the
 configuration is shared during the whole runtime.
 
 ### setup
 
-Initializes the map of OffChainDataAccessors.
+Initializes the map of OffChainDataAdapters.
 
 **Parameters**
 
@@ -876,21 +880,21 @@ Initializes the map of OffChainDataAccessors.
 
 ### \_\_reset
 
-Drops all pre-configured OffChainDataAccessors. Useful for testing.
+Drops all pre-configured OffChainDataAdapters. Useful for testing.
 
-### getAccessor
+### getAdapter
 
-Returns a fresh instance of an appropriate OffChainDataAccessor by
-calling the `create` function from the accessor's configuration.
+Returns a fresh instance of an appropriate OffChainDataAdapter by
+calling the `create` function from the adapter's configuration.
 
 **Parameters**
 
 -   `schema` **[string][98]?** 
 
 
--   Throws **[Error][100]** when schema is not defined or accessor for this schema does not exist
+-   Throws **[Error][100]** when schema is not defined or adapter for this schema does not exist
 
-Returns **[Promise][106]&lt;[OffChainDataAccessorInterface][137]>** 
+Returns **[Promise][106]&lt;[OffChainDataAdapterInterface][138]>** 
 
 ## RemotelyBackedDataset
 
@@ -951,7 +955,7 @@ be synced from the remote storage (if the dataset is marked as deployed).
 
 Is dataset marked as obsolete?
 
-Returns **[Boolean][133]** 
+Returns **[Boolean][134]** 
 
 ### markObsolete
 
@@ -963,7 +967,7 @@ but merely serves as a flag to prevent further interaction with this object.
 
 Is dataset deployed to the remote storage?
 
-Returns **[Boolean][133]** 
+Returns **[Boolean][134]** 
 
 ### markDeployed
 
@@ -1018,13 +1022,13 @@ Generic factory method.
 Definition of a data field that is stored off-chain.
 This may be recursive.
 
-Type: {name: [string][98], isStoragePointer: [boolean][133]?, fields: [Array][101]&lt;([FieldDefType][138] \| [string][98])>?}
+Type: {name: [string][98], isStoragePointer: [boolean][134]?, fields: [Array][101]&lt;([FieldDefType][139] \| [string][98])>?}
 
 **Properties**
 
 -   `name` **[string][98]** 
--   `isStoragePointer` **[boolean][133]?** 
--   `fields` **[Array][101]&lt;([FieldDefType][138] \| [string][98])>?** 
+-   `isStoragePointer` **[boolean][134]?** 
+-   `fields` **[Array][101]&lt;([FieldDefType][139] \| [string][98])>?** 
 
 ## StoragePointer
 
@@ -1066,7 +1070,7 @@ field above may contain a complex JSON object.
 **Parameters**
 
 -   `url` **[string][98]** where to look for the data
--   `fields` **[Array][101]&lt;[FieldDefType][138]>** definition from which are generated getters
+-   `fields` **[Array][101]&lt;[FieldDefType][139]>** definition from which are generated getters
 
 ### \_genericGetter
 
@@ -1099,14 +1103,14 @@ Returns **[string][98]?**
 
 ### \_getOffChainDataClient
 
-Returns appropriate implementation of `OffChainDataAccessorInterface`
-based on schema. Uses `OffChainDataClient.getAccessor` factory method.
+Returns appropriate implementation of `OffChainDataAdapterInterface`
+based on schema. Uses `OffChainDataClient.getAdapter` factory method.
 
-Returns **[Promise][106]&lt;[OffChainDataAccessorInterface][137]>** 
+Returns **[Promise][106]&lt;[OffChainDataAdapterInterface][138]>** 
 
 ### \_downloadFromStorage
 
-Gets the data document via `OffChainDataAccessorInterface`.
+Gets the data document via `OffChainDataAdapterInterface`.
 If nothing is returned, might return an empty object.
 
 Returns **[Promise][106]&lt;{}>** 
@@ -1121,7 +1125,7 @@ instance
 **Parameters**
 
 -   `url` **[string][98]** where to look for data document. It has to include schema, i. e. `https://example.com/data`
--   `fields` **[Array][101]&lt;([FieldDefType][138] \| [string][98])>** list of top-level fields in the referred document
+-   `fields` **[Array][101]&lt;([FieldDefType][139] \| [string][98])>** list of top-level fields in the referred document
 
 Returns **[StoragePointer][118]** 
 
@@ -1143,7 +1147,7 @@ Is address a zero address? Uses a bignumber.js test
 
 -   `address` **[string][98]** 
 
-Returns **[boolean][133]** 
+Returns **[boolean][134]** 
 
 ### applyGasCoefficient
 
@@ -1202,7 +1206,7 @@ Proxy method for `web3.eth.getTransactionReceipt`
 
 -   `txHash` **[string][98]** 
 
-Returns **[TxReceiptInterface][132]** 
+Returns **[TxReceiptInterface][133]** 
 
 ### getTransaction
 
@@ -1212,7 +1216,7 @@ Proxy method for `web3.eth.getTransaction`
 
 -   `txHash` **[string][98]** 
 
-Returns **[Promise][106]&lt;[TxInterface][139]>** 
+Returns **[Promise][106]&lt;[TxInterface][140]>** 
 
 ### createInstance
 
@@ -1246,7 +1250,7 @@ Sets up an initialized Web3 instance for later use
 It is not possible to do any operations on a destroyed
 wallet. Wallet is destroyed by calling the `destroy()` method.
 
-Returns **[boolean][133]** 
+Returns **[boolean][134]** 
 
 ### getAddress
 
@@ -1280,8 +1284,8 @@ may run an `onReceipt` callback after receiving the `receipt` event.
 
 **Parameters**
 
--   `transactionData` **[TransactionDataInterface][134]** 
--   `onReceipt` **function (receipt: [TxReceiptInterface][132]): void?** 
+-   `transactionData` **[TransactionDataInterface][135]** 
+-   `onReceipt` **function (receipt: [TxReceiptInterface][133]): void?** 
 
 
 -   Throws **[Error][100]** When wallet was destroyed.
@@ -1413,7 +1417,7 @@ Returns **[Wallet][115]**
 
 [45]: #wtindexinterface
 
-[46]: #offchaindataaccessorinterface
+[46]: #offchaindataadapterinterface
 
 [47]: #datamodelinterface
 
@@ -1443,7 +1447,7 @@ Returns **[Wallet][115]**
 
 [60]: #__reset
 
-[61]: #getaccessor
+[61]: #getadapter
 
 [62]: #remotelybackeddataset
 
@@ -1581,22 +1585,24 @@ Returns **[Wallet][115]**
 
 [129]: #wtlibs
 
-[130]: https://web3js.readthedocs.io/en/1.0/web3-eth-accounts.html#signtransaction
+[130]: https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#contract-estimategas
 
-[131]: http://web3js.readthedocs.io/en/1.0/web3-eth.html#gettransaction
+[131]: https://web3js.readthedocs.io/en/1.0/web3-eth-accounts.html#signtransaction
 
-[132]: #txreceiptinterface
+[132]: http://web3js.readthedocs.io/en/1.0/web3-eth.html#gettransaction
 
-[133]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[133]: #txreceiptinterface
 
-[134]: #transactiondatainterface
+[134]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[135]: https://medium.com/@julien.m./what-is-an-ethereum-keystore-file-86c8c5917b97
+[135]: #transactiondatainterface
 
-[136]: https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
+[136]: https://medium.com/@julien.m./what-is-an-ethereum-keystore-file-86c8c5917b97
 
-[137]: #offchaindataaccessorinterface
+[137]: https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
 
-[138]: #fielddeftype
+[138]: #offchaindataadapterinterface
 
-[139]: #txinterface
+[139]: #fielddeftype
+
+[140]: #txinterface

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,10 +220,10 @@
         "zeppelin-solidity": "^1.6.0"
       }
     },
-    "@windingtree/off-chain-accessor-in-memory": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@windingtree/off-chain-accessor-in-memory/-/off-chain-accessor-in-memory-1.0.0.tgz",
-      "integrity": "sha512-LolssSoMW9c5PHNTL7pct9yP1E1+wi3hzU6yAtW0U7C64FLpgPj04/g0aHBqSRGx9V9oHppM9wGJB+vfekExVQ==",
+    "@windingtree/off-chain-adapter-in-memory": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@windingtree/off-chain-adapter-in-memory/-/off-chain-adapter-in-memory-2.0.0.tgz",
+      "integrity": "sha512-u4fuR1ndELfJWJzpV/nk06bivSLF2UMAi8Fg4yctk0mbyfT9ZF5GOvN1s37zOytllCiAnXbnkjVIcuPcE1d4hw==",
       "requires": {
         "js-sha3": "^0.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@windingtree/lif-token": "^0.1.2-erc827",
-    "@windingtree/off-chain-accessor-in-memory": "^1.0.0",
+    "@windingtree/off-chain-adapter-in-memory": "^2.0.0",
     "@windingtree/wt-contracts": "^0.2.0",
     "bignumber.js": "^3.0.1",
     "ethereumjs-util": "^5.1.5",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import type { DataModelOptionsType } from './data-model';
 import type { OffChainDataClientOptionsType } from './off-chain-data-client';
-import type { WTIndexInterface, AdaptedTxResultsInterface, OffChainDataAccessorInterface, WalletInterface, KeystoreV3Interface } from './interfaces';
+import type { WTIndexInterface, AdaptedTxResultsInterface, OffChainDataAdapterInterface, WalletInterface, KeystoreV3Interface } from './interfaces';
 import DataModel from './data-model';
 import OffChainDataClient from './off-chain-data-client';
 
@@ -61,8 +61,8 @@ class WTLibs {
     return this.dataModel.createWallet(jsonWallet);
   }
 
-  async getOffChainDataClient (schema: string): Promise<OffChainDataAccessorInterface> {
-    return OffChainDataClient.getAccessor(schema);
+  async getOffChainDataClient (schema: string): Promise<OffChainDataAdapterInterface> {
+    return OffChainDataClient.getAdapter(schema);
   }
 }
 

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -81,7 +81,7 @@ export interface WTIndexInterface {
 /**
  * Interface for an off-chain storage read.
  */
-export interface OffChainDataAccessorInterface {
+export interface OffChainDataAdapterInterface {
   // Upload new dataset to an off-chain storage
   upload(data: {[string]: Object}): Promise<string>;
   // Change data on given url

--- a/src/off-chain-data-client.js
+++ b/src/off-chain-data-client.js
@@ -1,13 +1,13 @@
 // @flow
-import type { OffChainDataAccessorInterface } from './interfaces';
+import type { OffChainDataAdapterInterface } from './interfaces';
 
 /**
  * OffChainDataClientOptionsType
  */
 export type OffChainDataClientOptionsType = {
-  accessors: {[schema: string]: {
+  adapters: {[schema: string]: {
     options: Object;
-    create: (options: Object) => OffChainDataAccessorInterface
+    create: (options: Object) => OffChainDataAdapterInterface
   }}
 };
 
@@ -15,46 +15,46 @@ let offChainDataOptions: OffChainDataClientOptionsType;
 
 /**
  * OffChainDataClient is a static factory class that is responsible
- * for creating proper instances of OffChainDataAccessorInterface.
+ * for creating proper instances of OffChainDataAdapterInterface.
  * It is configured during the library initialization.
  *
- * Please bear in mind, that once the accessors are configured, the
+ * Please bear in mind, that once the adapters are configured, the
  * configuration is shared during the whole runtime.
  */
 class OffChainDataClient {
-  accessors: Object;
+  adapters: Object;
 
   /**
-   * Initializes the map of OffChainDataAccessors.
+   * Initializes the map of OffChainDataAdapters.
    *
    * @param  {OffChainDataClientOptionsType}
    */
   static setup (options: OffChainDataClientOptionsType) {
     offChainDataOptions = options || {};
-    if (!offChainDataOptions.accessors) {
-      offChainDataOptions.accessors = {};
+    if (!offChainDataOptions.adapters) {
+      offChainDataOptions.adapters = {};
     }
   }
 
   /**
-   * Drops all pre-configured OffChainDataAccessors. Useful for testing.
+   * Drops all pre-configured OffChainDataAdapters. Useful for testing.
    */
   static __reset () {
-    offChainDataOptions.accessors = {};
+    offChainDataOptions.adapters = {};
   }
 
   /**
-   * Returns a fresh instance of an appropriate OffChainDataAccessor by
-   * calling the `create` function from the accessor's configuration.
+   * Returns a fresh instance of an appropriate OffChainDataAdapter by
+   * calling the `create` function from the adapter's configuration.
    *
-   * @throws {Error} when schema is not defined or accessor for this schema does not exist
+   * @throws {Error} when schema is not defined or adapter for this schema does not exist
    */
-  static async getAccessor (schema: ?string): Promise<OffChainDataAccessorInterface> {
-    if (!schema || !offChainDataOptions.accessors[schema]) {
+  static async getAdapter (schema: ?string): Promise<OffChainDataAdapterInterface> {
+    if (!schema || !offChainDataOptions.adapters[schema]) {
       throw new Error(`Unsupported data storage type: ${schema || 'null'}`);
     }
-    const accessor = offChainDataOptions.accessors[schema];
-    return accessor.create(accessor.options);
+    const adapter = offChainDataOptions.adapters[schema];
+    return adapter.create(adapter.options);
   }
 }
 

--- a/src/storage-pointer.js
+++ b/src/storage-pointer.js
@@ -1,5 +1,5 @@
 // @flow
-import type { OffChainDataAccessorInterface } from './interfaces';
+import type { OffChainDataAdapterInterface } from './interfaces';
 import OffChainDataClient from './off-chain-data-client';
 
 /**
@@ -59,7 +59,7 @@ class StoragePointer {
   __downloaded: boolean;
   __data: ?{[string]: Object};
   __fields: Array<FieldDefType>;
-  __accessor: OffChainDataAccessorInterface;
+  __adapter: OffChainDataAdapterInterface;
 
   /**
    * Returns a new instance of StoragePointer.
@@ -92,7 +92,7 @@ class StoragePointer {
 
   /**
    * Detects schema from the url, based on that instantiates an appropriate
-   * `OffChainDataAccessorInterface` implementation and sets up all data
+   * `OffChainDataAdapterInterface` implementation and sets up all data
    * getters.
    *
    * @param  {string} url where to look for the data
@@ -159,23 +159,23 @@ class StoragePointer {
   }
 
   /**
-   * Returns appropriate implementation of `OffChainDataAccessorInterface`
-   * based on schema. Uses `OffChainDataClient.getAccessor` factory method.
+   * Returns appropriate implementation of `OffChainDataAdapterInterface`
+   * based on schema. Uses `OffChainDataClient.getAdapter` factory method.
    */
-  async _getOffChainDataClient (): Promise<OffChainDataAccessorInterface> {
-    if (!this.__accessor) {
-      this.__accessor = await OffChainDataClient.getAccessor(this._detectSchema(this.ref));
+  async _getOffChainDataClient (): Promise<OffChainDataAdapterInterface> {
+    if (!this.__adapter) {
+      this.__adapter = await OffChainDataClient.getAdapter(this._detectSchema(this.ref));
     }
-    return this.__accessor;
+    return this.__adapter;
   }
 
   /**
-   * Gets the data document via `OffChainDataAccessorInterface`.
+   * Gets the data document via `OffChainDataAdapterInterface`.
    * If nothing is returned, might return an empty object.
    */
   async _downloadFromStorage (): Promise<{[string]: Object}> {
-    const accessor = await this._getOffChainDataClient();
-    const result = await accessor.download(this.ref);
+    const adapter = await this._getOffChainDataClient();
+    const result = await adapter.download(this.ref);
     this.__downloaded = true;
     return result || {};
   }

--- a/test/utils/data-model-definition.js
+++ b/test/utils/data-model-definition.js
@@ -1,5 +1,5 @@
 import offChainData from './data/off-chain-data.json';
-import { accessor as InMemoryAccessor, storageInstance } from '@windingtree/off-chain-accessor-in-memory';
+import { adapter as InMemoryAdapter, storageInstance } from '@windingtree/off-chain-adapter-in-memory';
 
 export const Web3UriBackedDataModel = {
   emptyConfig: {},
@@ -8,10 +8,10 @@ export const Web3UriBackedDataModel = {
       provider: 'http://localhost:8545',
     },
     offChainDataOptions: {
-      accessors: {
+      adapters: {
         json: {
           create: () => {
-            return new InMemoryAccessor();
+            return new InMemoryAdapter();
           },
         },
       },

--- a/test/wt-libs/index.spec.js
+++ b/test/wt-libs/index.spec.js
@@ -40,7 +40,7 @@ describe('WTLibs', () => {
           random: '1234',
         },
         offChainDataOptions: {
-          accessors: {
+          adapters: {
             json: {
               create: () => {
                 return true;
@@ -49,8 +49,8 @@ describe('WTLibs', () => {
           },
         },
       });
-      const accessor = await libs.getOffChainDataClient('json');
-      assert.isDefined(accessor);
+      const adapter = await libs.getOffChainDataClient('json');
+      assert.isDefined(adapter);
       OffChainDataClient.__reset();
     });
   });

--- a/test/wt-libs/off-chain-data-client.spec.js
+++ b/test/wt-libs/off-chain-data-client.spec.js
@@ -1,14 +1,14 @@
 import { assert } from 'chai';
 import OffChainDataClient from '../../src/off-chain-data-client';
-import { accessor as InMemoryAccessor } from '@windingtree/off-chain-accessor-in-memory';
+import { adapter as InMemoryAdapter } from '@windingtree/off-chain-adapter-in-memory';
 
 describe('WTLibs.OffChainDataClient', () => {
   beforeEach(() => {
     OffChainDataClient.setup({
-      accessors: {
+      adapters: {
         json: {
           create: () => {
-            return new InMemoryAccessor();
+            return new InMemoryAdapter();
           },
         },
       },
@@ -19,15 +19,15 @@ describe('WTLibs.OffChainDataClient', () => {
     OffChainDataClient.__reset();
   });
 
-  it('should return proper accessor', async () => {
-    const accessor = await OffChainDataClient.getAccessor('json');
-    assert.isDefined(accessor);
-    assert.isDefined(accessor._getHash);
+  it('should return proper adapter', async () => {
+    const adapter = await OffChainDataClient.getAdapter('json');
+    assert.isDefined(adapter);
+    assert.isDefined(adapter._getHash);
   });
 
-  it('should throw when no accessor is found for given schema', async () => {
+  it('should throw when no adapter is found for given schema', async () => {
     try {
-      await OffChainDataClient.getAccessor('non-existent');
+      await OffChainDataClient.getAdapter('non-existent');
       throw new Error('should have never been called');
     } catch (e) {
       assert.match(e.message, /unsupported data storage type/i);

--- a/test/wt-libs/storage-pointer.spec.js
+++ b/test/wt-libs/storage-pointer.spec.js
@@ -2,15 +2,15 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 import StoragePointer from '../../src/storage-pointer';
 import OffChainDataClient from '../../src/off-chain-data-client';
-import { accessor as InMemoryAccessor } from '@windingtree/off-chain-accessor-in-memory';
+import { adapter as InMemoryAdapter } from '@windingtree/off-chain-adapter-in-memory';
 
 describe('WTLibs.StoragePointer', () => {
   beforeEach(() => {
     OffChainDataClient.setup({
-      accessors: {
+      adapters: {
         json: {
           create: () => {
-            return new InMemoryAccessor();
+            return new InMemoryAdapter();
           },
         },
       },
@@ -79,21 +79,21 @@ describe('WTLibs.StoragePointer', () => {
     assert.equal(dldSpy.callCount, 1);
   });
 
-  it('should properly instantiate OffChainDataAccessor', async () => {
+  it('should properly instantiate OffChainDataAdapter', async () => {
     const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
-    assert.isUndefined(pointer.__accessor);
+    assert.isUndefined(pointer.__adapter);
     await pointer.contents.some;
-    assert.isDefined(pointer.__accessor);
+    assert.isDefined(pointer.__adapter);
   });
 
-  it('should reuse OffChainDataAccessor instance', async () => {
-    const getAccessorSpy = sinon.spy(OffChainDataClient, 'getAccessor');
+  it('should reuse OffChainDataAdapter instance', async () => {
+    const getAdapterSpy = sinon.spy(OffChainDataClient, 'getAdapter');
     const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
-    assert.equal(getAccessorSpy.callCount, 0);
+    assert.equal(getAdapterSpy.callCount, 0);
     await pointer.contents.some;
-    assert.equal(getAccessorSpy.callCount, 1);
+    assert.equal(getAdapterSpy.callCount, 1);
     await pointer._getOffChainDataClient();
-    assert.equal(getAccessorSpy.callCount, 1);
+    assert.equal(getAdapterSpy.callCount, 1);
   });
 
   it('should throw when an unsupported schema is encountered', async () => {


### PR DESCRIPTION
Including the library configuration and `in-memory` adapter dependency.

As we've discussed in a planning meeting on 2018-06-14