### PR TITLE
breaking: Syncs naming with swagger in hotel descriptive data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5580,6 +5580,7 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -5601,7 +5602,8 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -5615,11 +5617,13 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -5630,15 +5634,18 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -5673,7 +5680,8 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -5700,7 +5708,8 @@
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -5809,6 +5818,7 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -5850,6 +5860,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -5861,7 +5872,8 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -5924,11 +5936,13 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
+          "optional": true,
           "requires": {
             "mime-db": "1.27.0"
           }
@@ -5996,7 +6010,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -6045,7 +6060,8 @@
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -6078,6 +6094,7 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -6126,7 +6143,8 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -6146,6 +6164,7 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -6176,6 +6195,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6185,6 +6205,7 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -6209,6 +6230,7 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -6258,7 +6280,8 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,9 +236,9 @@
       }
     },
     "@windingtree/wt-contracts": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@windingtree/wt-contracts/-/wt-contracts-0.2.0.tgz",
-      "integrity": "sha512-ivcU58PfH7FCdUMjWxAAp/Y5dTe3U8dHkVxaTjJiZHWJLO/dS6WgJHsOJnNLu4t/6a5Nym9+qKuiDV8rNbBUHA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@windingtree/wt-contracts/-/wt-contracts-0.2.2.tgz",
+      "integrity": "sha512-Jyi9CKSHFxlUcu124MwuJhVwJ4HMPEWMci4q+SM9spznqGcqlhrcSP/FGThVwVoLp1REabP9jIIkXtme6k9RvA==",
       "requires": {
         "@windingtree/lif-token": "^0.1.2-erc827",
         "abi-decoder": "^1.1.0",
@@ -252,13 +252,9 @@
       },
       "dependencies": {
         "zeppelin-solidity": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.8.0.tgz",
-          "integrity": "sha512-7Mxq6Y7EES0PSLrRF6v0EVYqBVRRo8hFrr7m3jEs69VbbQ5kpANzizeEdbP1/PWKSOmBOg208qP2vSA0FlzFLA==",
-          "requires": {
-            "dotenv": "^4.0.0",
-            "ethjs-abi": "^0.2.1"
-          }
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.10.0.tgz",
+          "integrity": "sha512-+7vO3ltfNdCJ8E8NKFlC0PKQUh9PTFm71o1u0vgZdJ0U20NTMRkYx/jepa0+B//vikFv4P6Zf74AULqsKJ/xhQ=="
         }
       }
     },
@@ -5580,7 +5576,6 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -5602,8 +5597,7 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -5617,8 +5611,7 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -5634,18 +5627,15 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -5708,8 +5698,7 @@
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -5818,7 +5807,6 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -5872,8 +5860,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -6060,8 +6047,7 @@
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -6094,7 +6080,6 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -6143,8 +6128,7 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "5.3.0",
@@ -6164,7 +6148,6 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -6195,7 +6178,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6205,7 +6187,6 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -6230,7 +6211,6 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -6280,8 +6260,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "uuid": {
           "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@windingtree/lif-token": "^0.1.2-erc827",
     "@windingtree/off-chain-adapter-in-memory": "^2.0.0",
-    "@windingtree/wt-contracts": "^0.2.0",
+    "@windingtree/wt-contracts": "^0.2.2",
     "bignumber.js": "^3.0.1",
     "ethereumjs-util": "^5.1.5",
     "lodash": "^4.17.5",

--- a/src/data-interfaces.js
+++ b/src/data-interfaces.js
@@ -1,6 +1,6 @@
 // @flow
 /**
- * Index file for more data urls. This is the
+ * Index file for more data URIs. This is the
  * initial document that blockchain is pointing to.
  */
 export interface HotelDataIndex {

--- a/src/data-interfaces.js
+++ b/src/data-interfaces.js
@@ -4,7 +4,7 @@
  * initial document that blockchain is pointing to.
  */
 export interface HotelDataIndex {
-  descriptionUrl: string
+  descriptionUri: string
 }
 
 /**
@@ -16,32 +16,41 @@ export interface LocationInterface {
 }
 
 /**
+ * Generic additional contact.
+ */
+export interface AdditionalContact {
+  title: string;
+  value: string
+}
+
+/**
  * Generic contact.
  */
 export interface ContactInterface {
   email?: Promise<?string> | ?string;
   phone?: Promise<?string> | ?string;
   url?: Promise<?string> | ?string;
-  ethereum?: Promise<?string> | ?string
+  ethereum?: Promise<?string> | ?string;
+  additionalContacts?: Promise<?Array<AdditionalContact>> | ?Array<AdditionalContact>
 }
 
 /**
  * A map of hotel contacts.
  */
 export interface ContactsInterface {
-  general: ?ContactInterface
+  general: ContactInterface
 }
 
 /**
  * Generic address interface.
  */
 export interface AddressInterface {
-  line1?: Promise<?string> | ?string;
+  line1?: Promise<string> | string;
   line2?: Promise<?string> | ?string;
-  zip?: Promise<?string> | ?string;
-  city?: Promise<?string> | ?string;
+  postalCode?: Promise<?string> | ?string;
+  city?: Promise<string> | string;
   state?: Promise<?string> | ?string;
-  country?: Promise<?string> | ?string
+  country?: Promise<string> | string
 }
 
 /**
@@ -49,15 +58,14 @@ export interface AddressInterface {
  * @see https://github.com/windingtree/wt-js-libs/issues/125
  */
 export interface HotelDescriptionInterface {
-  name?: Promise<?string> | ?string;
-  description?: Promise<?string> | ?string;
-  contacts?: Promise<?ContactsInterface> | ?ContactsInterface;
-  address?: Promise<?AddressInterface> | ?AddressInterface;
+  name?: Promise<string> | string;
+  description?: Promise<string> | string;
+  contacts?: Promise<ContactsInterface> | ContactsInterface;
+  address?: Promise<AddressInterface> | AddressInterface;
   location?: Promise<?LocationInterface> | ?LocationInterface;
-  timezone?: Promise<?string> | ?string;
-  currency?: Promise<?string> | ?string;
+  timezone?: Promise<string> | string;
+  currency?: Promise<string> | string;
   images?: Promise<?Array<string>> | ?Array<string>;
   amenities?: Promise<?Array<string>> | ?Array<string>;
-  createdAt: Promise<?string> | ?string;
-  updatedAt: Promise<?string> | ?string
+  updatedAt: Promise<string> | string
 }

--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -7,7 +7,7 @@ import StoragePointer from '../storage-pointer';
 
 /**
  * Wrapper class for a hotel backed by a smart contract on
- * Ethereum that's holding `url` pointer to its data.
+ * Ethereum that's holding `dataUri` pointer to its data.
  *
  * It provides an accessor to such data in a form of
  * `StoragePointer` instance under `dataIndex` property.
@@ -19,7 +19,7 @@ class OnChainHotel implements HotelInterface {
   address: Promise<?string> | ?string;
 
   // provided by eth backed dataset
-  url: Promise<?string> | ?string;
+  dataUri: Promise<?string> | ?string;
   manager: Promise<?string> | ?string;
   
   web3Utils: Utils;
@@ -28,7 +28,7 @@ class OnChainHotel implements HotelInterface {
   contractInstance: Object;
   onChainDataset: RemotelyBackedDataset;
 
-  // Representation of data stored on url
+  // Representation of data stored on dataUri
   _dataIndex: StoragePointer;
 
   /**
@@ -64,9 +64,9 @@ class OnChainHotel implements HotelInterface {
     this.onChainDataset = RemotelyBackedDataset.createInstance();
     this.onChainDataset.bindProperties({
       fields: {
-        url: {
+        dataUri: {
           remoteGetter: async (): Promise<?string> => {
-            return (await this.__getContractInstance()).methods.url().call();
+            return (await this.__getContractInstance()).methods.dataUri().call();
           },
           remoteSetter: this.__editInfoOnChain.bind(this),
         },
@@ -84,17 +84,17 @@ class OnChainHotel implements HotelInterface {
 
   /**
    * Async getter for `StoragePointer` instance.
-   * Since it has to eventually access the `url`
+   * Since it has to eventually access the `dataUri`
    * field stored on-chain, it is lazy loaded.
    * Any data structure that is accessed by StoragePointer
    * instance has for now be known beforehand, thus the whole
-   * data format of hotel data on `url` is specified here.
+   * data format of hotel data on `dataUri` is specified here.
    *
    */
   get dataIndex (): Promise<StoragePointer> {
     return (async () => {
       if (!this._dataIndex) {
-        this._dataIndex = StoragePointer.createInstance(await this.url, [
+        this._dataIndex = StoragePointer.createInstance(await this.dataUri, [
           {
             name: 'description',
             isStoragePointer: true,
@@ -119,7 +119,7 @@ class OnChainHotel implements HotelInterface {
   }
 
   /**
-   * Update manager and url properties. Url can never be nulled. Manager
+   * Update manager and dataUri properties. dataUri can never be nulled. Manager
    * can never be nulled. Manager can be changed only for an un-deployed
    * contract (without address).
    * @param {HotelOnChainDataInterface} newData
@@ -128,8 +128,8 @@ class OnChainHotel implements HotelInterface {
     if (newData.manager && !this.address) {
       this.manager = newData.manager;
     }
-    if (newData.url) {
-      this.url = newData.url;
+    if (newData.dataUri) {
+      this.dataUri = newData.dataUri;
     }
   }
 
@@ -143,7 +143,7 @@ class OnChainHotel implements HotelInterface {
   async toPlainObject (): Promise<HotelOnChainDataInterface> {
     return {
       manager: await this.manager,
-      url: await this.url,
+      dataUri: await this.dataUri,
       address: this.address,
     };
   }
@@ -159,14 +159,14 @@ class OnChainHotel implements HotelInterface {
   }
 
   /**
-   * Updates url on-chain. Used internally as a remoteSetter for `url` property.
+   * Updates dataUri on-chain. Used internally as a remoteSetter for `dataUri` property.
    *
    * @param {WalletInterface} wallet that signs the transaction
    * @param {TransactionOptionsInterface} options object, only `from` property is currently used, all others are ignored in this implementation
    * @return {Promise<string>} resulting transaction hash
    */
   async __editInfoOnChain (wallet: WalletInterface, transactionOptions: TransactionOptionsInterface): Promise<string> {
-    const data = (await this.__getContractInstance()).methods.editInfo(await this.url).encodeABI();
+    const data = (await this.__getContractInstance()).methods.editInfo(await this.dataUri).encodeABI();
     const estimate = await this.indexContract.methods.callHotel(this.address, data).estimateGas(transactionOptions);
     const txData = this.indexContract.methods.callHotel(this.address, data).encodeABI();
     const transactionData = {
@@ -204,9 +204,9 @@ class OnChainHotel implements HotelInterface {
       await this.web3Utils.determineCurrentAddressNonce(this.indexContract.options.address)
     );
     // Create hotel on-network
-    const url = await this.url;
-    const estimate = await this.indexContract.methods.registerHotel(url).estimateGas(transactionOptions);
-    const data = this.indexContract.methods.registerHotel(url).encodeABI();
+    const dataUri = await this.dataUri;
+    const estimate = await this.indexContract.methods.registerHotel(dataUri).estimateGas(transactionOptions);
+    const data = this.indexContract.methods.registerHotel(dataUri).encodeABI();
     const transactionData = {
       nonce: await this.web3Utils.determineCurrentAddressNonce(transactionOptions.from),
       data: data,
@@ -232,14 +232,14 @@ class OnChainHotel implements HotelInterface {
    * @param {WalletInterface} wallet that signs the transaction
    * @param {TransactionOptionsInterface} options object that is passed to all remote data setters
    * @throws {Error} When the underlying contract is not yet deployed.
-   * @throws {Error} When url is empty.
+   * @throws {Error} When dataUri is empty.
    * @return {Promise<Array<string>>} List of transaction hashes
    */
   async updateOnChainData (wallet: WalletInterface, transactionOptions: TransactionOptionsInterface): Promise<Array<string>> {
     // pre-check if contract is available at all and fail fast
     await this.__getContractInstance();
-    if (!(await this.url)) {
-      throw new Error('Cannot set url when it is not provided');
+    if (!(await this.dataUri)) {
+      throw new Error('Cannot set dataUri when it is not provided');
     }
     // We have to clone options for each dataset as they may get modified
     // along the way

--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -109,7 +109,6 @@ class OnChainHotel implements HotelInterface {
               'currency',
               'images',
               'amenities',
-              'createdAt',
               'updatedAt',
             ],
           },

--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -96,7 +96,7 @@ class OnChainHotel implements HotelInterface {
       if (!this._dataIndex) {
         this._dataIndex = StoragePointer.createInstance(await this.dataUri, [
           {
-            name: 'description',
+            name: 'descriptionUri',
             isStoragePointer: true,
             // This should always be in line with publicly declared HotelDescriptionInterface
             fields: [

--- a/src/data-model/wt-index.js
+++ b/src/data-model/wt-index.js
@@ -45,13 +45,13 @@ class WTIndex implements WTIndexInterface {
    * to be mined, but as fast as possible returns a list of transaction IDs
    * and the new hotel on chain address.
    *
-   * @throws {Error} When hotelData does not contain url property.
+   * @throws {Error} When hotelData does not contain dataUri property.
    * @throws {Error} When anything goes wrong during communication with the network.
    */
   async addHotel (wallet: WalletInterface, hotelData: HotelOnChainDataInterface): Promise<AddHotelResponseInterface> {
-    // TODO validate hotelData.url format schema://more-data
-    if (!await hotelData.url) {
-      throw new Error('Cannot add hotel: Missing url');
+    // TODO validate hotelData.dataUri format schema://more-data
+    if (!await hotelData.dataUri) {
+      throw new Error('Cannot add hotel: Missing dataUri');
     }
     const hotelManager = await hotelData.manager;
     if (!hotelManager) {

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -23,13 +23,13 @@ export interface AddHotelResponseInterface {
  *
  * - `address` is the network address.
  * - `manager` is the network address of hotel manager.
- * - `url` holds a pointer to the off-chain storage
+ * - `dataUri` holds a pointer to the off-chain storage
  * that is used internally to store data.
  */
 export interface HotelOnChainDataInterface {
   address: Promise<?string> | ?string;
   manager: Promise<?string> | ?string;
-  url: Promise<?string> | ?string
+  dataUri: Promise<?string> | ?string
 }
 
 /**
@@ -84,10 +84,10 @@ export interface WTIndexInterface {
 export interface OffChainDataAdapterInterface {
   // Upload new dataset to an off-chain storage
   upload(data: {[string]: Object}): Promise<string>;
-  // Change data on given url
-  update(url: string, data: {[string]: Object}): Promise<string>;
-  // Download content from given url
-  download(url: string): Promise<?{[string]: Object}>
+  // Change data on given uri
+  update(uri: string, data: {[string]: Object}): Promise<string>;
+  // Download content from given uri
+  download(uri: string): Promise<?{[string]: Object}>
 }
 
 /**

--- a/src/remotely-backed-dataset.js
+++ b/src/remotely-backed-dataset.js
@@ -51,9 +51,9 @@ class RemotelyBackedDataset {
    *
    * ```
    * {fields: {
-   *     url: {
+   *     dataUri: {
    *       remoteGetter: async (): Promise<?string> => {
-   *         return (await this.contract.url().call();
+   *         return (await this.contract.dataUri().call();
    *       },
    *       // this will usually return a transaction ID
    *       remoteSetter: async (): Promise<string> => {

--- a/src/storage-pointer.js
+++ b/src/storage-pointer.js
@@ -67,13 +67,13 @@ class StoragePointer {
    * Normalizes the `fields` format before creating the actual
    * instance
    *
-   * @param {string} url where to look for data document. It has to include schema, i. e. `https://example.com/data`
+   * @param {string} uri where to look for data document. It has to include schema, i. e. `https://example.com/data`
    * @param {Array<FieldDefType | string>} fields list of top-level fields in the referred document
-   * @throw {Error} if url is not defined
+   * @throw {Error} if uri is not defined
    */
-  static createInstance (url: ?string, fields: ?Array<FieldDefType | string>): StoragePointer {
-    if (!url) {
-      throw new Error('Cannot instantiate StoragePointer without url');
+  static createInstance (uri: ?string, fields: ?Array<FieldDefType | string>): StoragePointer {
+    if (!uri) {
+      throw new Error('Cannot instantiate StoragePointer without uri');
     }
     fields = fields || [];
     const normalizedFieldDef = [];
@@ -87,19 +87,19 @@ class StoragePointer {
         normalizedFieldDef.push(fieldDef);
       }
     }
-    return new StoragePointer(url, normalizedFieldDef);
+    return new StoragePointer(uri, normalizedFieldDef);
   }
 
   /**
-   * Detects schema from the url, based on that instantiates an appropriate
+   * Detects schema from the uri, based on that instantiates an appropriate
    * `OffChainDataAdapterInterface` implementation and sets up all data
    * getters.
    *
-   * @param  {string} url where to look for the data
+   * @param  {string} uri where to look for the data
    * @param  {Array<FieldDefType>} fields definition from which are generated getters
    */
-  constructor (url: string, fields: Array<FieldDefType>) {
-    this.ref = url;
+  constructor (uri: string, fields: Array<FieldDefType>) {
+    this.ref = uri;
     this.contents = {};
     this.__storagePointers = {};
     this.__downloaded = false;
@@ -123,7 +123,7 @@ class StoragePointer {
    * once any data field is accessed for the first time. Also
    * the recursive `StoragePointer`s are created here only
    * after the contents of the data is known, because we need
-   * to know the url to be able to instantiate the appropariate
+   * to know the uri to be able to instantiate the appropariate
    * `StoragePointer`.
    *
    * This behaviour might change in a way that we are able to
@@ -150,11 +150,11 @@ class StoragePointer {
   }
 
   /**
-   * Detects schema from an url, i. e.
+   * Detects schema from an uri, i. e.
    * from `json://some-data`, detects `json`.
    */
-  _detectSchema (url: string): ?string {
-    const matchResult = url.match(/(\w+):\/\//i);
+  _detectSchema (uri: string): ?string {
+    const matchResult = uri.match(/(\w+):\/\//i);
     return matchResult ? matchResult[1] : null;
   }
 

--- a/test/usage.spec.js
+++ b/test/usage.spec.js
@@ -32,7 +32,7 @@ describe('WTLibs usage', () => {
         },
       });
       const dataUri = await jsonClient.upload({
-        description: descUrl,
+        descriptionUri: descUrl,
       });
       const result = await index.addHotel(wallet, {
         manager: '0xd39ca7d186a37bb6bf48ae8abfeb4c687dc8f906',
@@ -50,7 +50,7 @@ describe('WTLibs usage', () => {
       assert.equal((await hotel.manager).toLowerCase(), '0xd39ca7d186a37bb6bf48ae8abfeb4c687dc8f906');
       assert.equal((await hotel.dataUri).toLowerCase(), dataUri);
       const dataIndex = await hotel.dataIndex;
-      const description = await dataIndex.contents.description;
+      const description = await dataIndex.contents.descriptionUri;
       assert.equal(await description.contents.name, 'Premium hotel');
 
       // We're removing the hotel to ensure clean slate after this test is run.
@@ -134,7 +134,7 @@ describe('WTLibs usage', () => {
       const hotelDataIndex = await hotel.dataIndex;
       assert.equal(hotelDataIndex.ref, await hotel.dataUri);
       assert.isDefined(hotelDataIndex.contents);
-      const descriptionContents = await hotelDataIndex.contents.description;
+      const descriptionContents = await hotelDataIndex.contents.descriptionUri;
       assert.isDefined(descriptionContents.contents);
       assert.isDefined(descriptionContents.ref);
       assert.equal(await descriptionContents.contents.name, 'First hotel');

--- a/test/usage.spec.js
+++ b/test/usage.spec.js
@@ -31,12 +31,12 @@ describe('WTLibs usage', () => {
           longitude: 'long',
         },
       });
-      const url = await jsonClient.upload({
+      const dataUri = await jsonClient.upload({
         description: descUrl,
       });
       const result = await index.addHotel(wallet, {
         manager: '0xd39ca7d186a37bb6bf48ae8abfeb4c687dc8f906',
-        url: url,
+        dataUri: dataUri,
       });
       assert.isDefined(result);
       assert.isDefined(result.address);
@@ -48,7 +48,7 @@ describe('WTLibs usage', () => {
       const hotel = await index.getHotel(result.address);
       // Don't bother with checksummed address format
       assert.equal((await hotel.manager).toLowerCase(), '0xd39ca7d186a37bb6bf48ae8abfeb4c687dc8f906');
-      assert.equal((await hotel.url).toLowerCase(), url);
+      assert.equal((await hotel.dataUri).toLowerCase(), dataUri);
       const dataIndex = await hotel.dataIndex;
       const description = await dataIndex.contents.description;
       assert.equal(await description.contents.name, 'Premium hotel');
@@ -63,7 +63,7 @@ describe('WTLibs usage', () => {
     it('should throw when hotel does not have a manager', async () => {
       try {
         await index.addHotel(wallet, {
-          url: 'json://some-data-hash',
+          dataUri: 'json://some-data-hash',
         });
         throw new Error('should not have been called');
       } catch (e) {
@@ -71,7 +71,7 @@ describe('WTLibs usage', () => {
       }
     });
 
-    it('should throw when hotel does not have an url', async () => {
+    it('should throw when hotel does not have a dataUri', async () => {
       try {
         await index.addHotel(wallet, {
           manager: '0xd39ca7d186a37bb6bf48ae8abfeb4c687dc8f906',
@@ -87,7 +87,7 @@ describe('WTLibs usage', () => {
     it('should remove hotel', async () => {
       const manager = '0xd39ca7d186a37bb6bf48ae8abfeb4c687dc8f906';
       const result = await index.addHotel(wallet, {
-        url: 'json://some-data-hash',
+        dataUri: 'json://some-data-hash',
         manager: manager,
       });
       assert.isDefined(result.address);
@@ -123,7 +123,7 @@ describe('WTLibs usage', () => {
       const address = '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769';
       const hotel = await index.getHotel(address);
       assert.isNotNull(hotel);
-      assert.equal(await hotel.url, 'json://urlone');
+      assert.equal(await hotel.dataUri, 'json://urlone');
       assert.equal(await hotel.address, address);
     });
 
@@ -132,7 +132,7 @@ describe('WTLibs usage', () => {
       const hotel = await index.getHotel(address);
       assert.isNotNull(hotel);
       const hotelDataIndex = await hotel.dataIndex;
-      assert.equal(hotelDataIndex.ref, await hotel.url);
+      assert.equal(hotelDataIndex.ref, await hotel.dataUri);
       assert.isDefined(hotelDataIndex.contents);
       const descriptionContents = await hotelDataIndex.contents.description;
       assert.isDefined(descriptionContents.contents);
@@ -148,7 +148,7 @@ describe('WTLibs usage', () => {
       const plainHotel = await hotel.toPlainObject();
       assert.isUndefined(plainHotel.toPlainObject);
       assert.equal(plainHotel.address, await hotel.address);
-      assert.equal(plainHotel.url, await hotel.url);
+      assert.equal(plainHotel.dataUri, await hotel.dataUri);
       assert.equal(plainHotel.manager, await hotel.manager);
     });
 
@@ -166,31 +166,31 @@ describe('WTLibs usage', () => {
     const hotelAddress = '0xbf18b616ac81830dd0c5d4b771f22fd8144fe769';
 
     it('should update hotel', async () => {
-      const newUrl = 'json://another-url';
+      const newUri = 'json://another-url';
       const hotel = await index.getHotel(hotelAddress);
-      const oldUrl = await hotel.url;
-      hotel.url = newUrl;
+      const oldUri = await hotel.dataUri;
+      hotel.dataUri = newUri;
       // Change the data
       const updateResult = await index.updateHotel(wallet, hotel);
       assert.isDefined(updateResult);
       // Verify
       const hotel2 = await index.getHotel(hotelAddress);
-      assert.equal(await hotel2.url, newUrl);
+      assert.equal(await hotel2.dataUri, newUri);
       // Change it back to keep data in line
-      hotel.url = oldUrl;
+      hotel.dataUri = oldUri;
       const updateResult2 = await index.updateHotel(wallet, hotel);
       assert.isDefined(updateResult2);
       // Verify it changed properly
       const hotel3 = await index.getHotel(hotelAddress);
-      assert.equal(await hotel3.url, oldUrl);
+      assert.equal(await hotel3.dataUri, oldUri);
     });
 
     it('should throw if hotel has no address', async () => {
       try {
-        const newUrl = 'json://another-random-hash';
+        const newUri = 'json://another-random-hash';
         const hotel = await index.getHotel(hotelAddress);
         hotel.address = undefined;
-        hotel.url = newUrl;
+        hotel.dataUri = newUri;
         await index.updateHotel(wallet, hotel);
         throw new Error('should not have been called');
       } catch (e) {
@@ -201,10 +201,10 @@ describe('WTLibs usage', () => {
 
     it('should throw if hotel has no manager', async () => {
       try {
-        const newUrl = 'json://another-random-hash';
+        const newUri = 'json://another-random-hash';
         const hotel = await index.getHotel(hotelAddress);
         hotel.manager = undefined;
-        hotel.url = newUrl;
+        hotel.dataUri = newUri;
         await index.updateHotel(wallet, hotel);
         throw new Error('should not have been called');
       } catch (e) {
@@ -213,15 +213,15 @@ describe('WTLibs usage', () => {
       }
     });
 
-    it('should throw if hotel has no url', async () => {
+    it('should throw if hotel has no dataUri', async () => {
       try {
         const hotel = await index.getHotel(hotelAddress);
-        hotel.url = undefined;
+        hotel.dataUri = undefined;
         await index.updateHotel(wallet, hotel);
         throw new Error('should not have been called');
       } catch (e) {
         assert.match(e.message, /cannot update hotel/i);
-        assert.match(e.message, /cannot set url when it is not provided/i);
+        assert.match(e.message, /cannot set dataUri when it is not provided/i);
       }
     });
 
@@ -229,7 +229,7 @@ describe('WTLibs usage', () => {
       try {
         const hotel = {
           address: '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826',
-          url: 'json://another-random-hash',
+          dataUri: 'json://another-random-hash',
         };
         await index.updateHotel(wallet, hotel);
         throw new Error('should not have been called');
@@ -248,7 +248,7 @@ describe('WTLibs usage', () => {
         assert.isDefined((await hotel.dataIndex).ref);
         const plainHotel = await hotel.toPlainObject();
         assert.equal(plainHotel.address, await hotel.address);
-        assert.equal(plainHotel.url, await hotel.url);
+        assert.equal(plainHotel.dataUri, await hotel.dataUri);
       }
     });
 

--- a/test/utils/data/off-chain-data.json
+++ b/test/utils/data/off-chain-data.json
@@ -1,9 +1,9 @@
 {
   "urlone": {
-    "description": "json://descriptionone"
+    "descriptionUri": "json://descriptionone"
   },
   "urltwo": {
-    "description": "json:descriptiontwo"
+    "descriptionUri": "json:descriptiontwo"
   },
   "descriptionone": {
     "name": "First hotel",

--- a/test/wt-libs/data-model/on-chain-hotel.spec.js
+++ b/test/wt-libs/data-model/on-chain-hotel.spec.js
@@ -19,7 +19,7 @@ describe('WTLibs.data-model.OnChainHotel', () => {
     contractsStub = {
       getHotelInstance: sinon.stub().resolves({
         methods: {
-          url: urlStub,
+          dataUri: urlStub,
           manager: managerStub,
           editInfo: helpers.stubContractMethodResult('info-edited'),
         },
@@ -46,12 +46,12 @@ describe('WTLibs.data-model.OnChainHotel', () => {
   });
 
   describe('initialize', () => {
-    it('should setup url and manager fields', async () => {
+    it('should setup dataUri and manager fields', async () => {
       const provider = new OnChainHotel(utilsStub, contractsStub, indexContractStub);
-      assert.isUndefined(provider.url);
+      assert.isUndefined(provider.dataUri);
       assert.isUndefined(provider.manager);
       await provider.initialize();
-      assert.isDefined(provider.url);
+      assert.isDefined(provider.dataUri);
       assert.isDefined(provider.manager);
       assert.isFalse(provider.onChainDataset.isDeployed());
     });
@@ -66,7 +66,7 @@ describe('WTLibs.data-model.OnChainHotel', () => {
     it('should setup StoragePointer during the first access', async () => {
       const storagePointerSpy = sinon.spy(StoragePointer, 'createInstance');
       const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub, 'fake-address');
-      provider.url = 'json://something-new';
+      provider.dataUri = 'json://something-new';
       assert.equal(storagePointerSpy.callCount, 0);
       await provider.dataIndex;
       assert.equal(storagePointerSpy.callCount, 1);
@@ -77,7 +77,7 @@ describe('WTLibs.data-model.OnChainHotel', () => {
     it('should reuse StoragePointer instance in successive calls', async () => {
       const storagePointerSpy = sinon.spy(StoragePointer, 'createInstance');
       const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub, 'fake-address');
-      provider.url = 'json://something-new';
+      provider.dataUri = 'json://something-new';
       assert.equal(storagePointerSpy.callCount, 0);
       await provider.dataIndex;
       assert.equal(storagePointerSpy.callCount, 1);
@@ -88,20 +88,20 @@ describe('WTLibs.data-model.OnChainHotel', () => {
   });
 
   describe('setLocalData', () => {
-    it('should set url', async () => {
+    it('should set dataUri', async () => {
       const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub);
-      await provider.setLocalData({ url: 'new-url' });
-      assert.equal(await provider.url, 'new-url');
-      await provider.setLocalData({ url: 'another-url' });
-      assert.equal(await provider.url, 'another-url');
+      await provider.setLocalData({ dataUri: 'new-url' });
+      assert.equal(await provider.dataUri, 'new-url');
+      await provider.setLocalData({ dataUri: 'another-url' });
+      assert.equal(await provider.dataUri, 'another-url');
     });
 
-    it('should never null url', async () => {
+    it('should never null dataUri', async () => {
       const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub);
-      await provider.setLocalData({ url: 'new-url' });
-      assert.equal(await provider.url, 'new-url');
-      await provider.setLocalData({ url: null });
-      assert.equal(await provider.url, 'new-url');
+      await provider.setLocalData({ dataUri: 'new-url' });
+      assert.equal(await provider.dataUri, 'new-url');
+      await provider.setLocalData({ dataUri: null });
+      assert.equal(await provider.dataUri, 'new-url');
     });
 
     it('should set manager only when not yet deployed', async () => {
@@ -125,19 +125,19 @@ describe('WTLibs.data-model.OnChainHotel', () => {
   describe('toPlainObject', () => {
     it('should return a plain JS object', async () => {
       const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub);
-      await provider.setLocalData({ url: 'some-url', manager: 'some-manager' });
+      await provider.setLocalData({ dataUri: 'some-url', manager: 'some-manager' });
       const plainHotel = await provider.toPlainObject();
-      assert.equal(plainHotel.url, 'some-url');
+      assert.equal(plainHotel.dataUri, 'some-url');
       assert.equal(plainHotel.manager, 'some-manager');
       assert.isUndefined(plainHotel.toPlainObject);
     });
   });
 
   describe('remote data definition', () => {
-    it('should setup remoteGetter for url', async () => {
+    it('should setup remoteGetter for dataUri', async () => {
       const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub, 'fake-address');
       assert.equal(urlStub().call.callCount, 0);
-      await provider.url;
+      await provider.dataUri;
       assert.equal(urlStub().call.callCount, 1);
     });
 
@@ -197,7 +197,7 @@ describe('WTLibs.data-model.OnChainHotel', () => {
     let provider;
     beforeEach(async () => {
       provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub, 'fake-address');
-      provider.url = 'something new';
+      provider.dataUri = 'something new';
     });
 
     it('should throw on an undeployed contract', async () => {
@@ -210,13 +210,13 @@ describe('WTLibs.data-model.OnChainHotel', () => {
       }
     });
 
-    it('should throw when updating hotel without url', async () => {
+    it('should throw when updating hotel without dataUri', async () => {
       try {
-        provider.url = null;
+        provider.dataUri = null;
         await provider.updateOnChainData(walletStub, {});
         throw new Error('should not have been called');
       } catch (e) {
-        assert.match(e.message, /cannot set url when it is not provided/i);
+        assert.match(e.message, /cannot set dataUri when it is not provided/i);
       }
     });
 

--- a/test/wt-libs/data-model/wt-index.spec.js
+++ b/test/wt-libs/data-model/wt-index.spec.js
@@ -44,7 +44,7 @@ describe('WTLibs.data-models.WTIndexDataProvider', () => {
       // TODO this might probably be emulated in another way
       const myIndexDataProvider = await WTIndexDataProvider.createInstance('some-other-address', dataModel.web3Utils, dataModel.web3Contracts);
       try {
-        await myIndexDataProvider.addHotel({}, { manager: 'b', url: 'aaa' });
+        await myIndexDataProvider.addHotel({}, { manager: 'b', dataUri: 'aaa' });
         throw new Error('should not have been called');
       } catch (e) {
         assert.match(e.message, /cannot add hotel/i);

--- a/test/wt-libs/storage-pointer.spec.js
+++ b/test/wt-libs/storage-pointer.spec.js
@@ -40,19 +40,19 @@ describe('WTLibs.StoragePointer', () => {
     }
   });
 
-  it('should throw on an empty url', () => {
+  it('should throw on an empty uri', () => {
     try {
       StoragePointer.createInstance('');
       throw new Error('should have never been called');
     } catch (e) {
-      assert.match(e.message, /without url/i);
+      assert.match(e.message, /without uri/i);
     }
 
     try {
       StoragePointer.createInstance();
       throw new Error('should have never been called');
     } catch (e) {
-      assert.match(e.message, /without url/i);
+      assert.match(e.message, /without uri/i);
     }
   });
 
@@ -197,7 +197,7 @@ describe('WTLibs.StoragePointer', () => {
     }
   });
 
-  it('should throw if StoragePointer cannot be set up due to bad url format', async () => {
+  it('should throw if StoragePointer cannot be set up due to bad uri format', async () => {
     try {
       const pointer = StoragePointer.createInstance('jsonxxurl', [{
         name: 'sp',


### PR DESCRIPTION
It's not yet fully compatible (RoomTypes are missing), but that's for another time.

~~Also we need to bring up to date `hotel.url` to `hotel.dataUri` - that's waiting for merge of https://github.com/windingtree/wt-contracts/pull/187 and a patch release of wt-contracts. We'll deal with that in another issue.~~