### PR TITLE
feature: Allows StoragePointer to be reset once the on-chain url changes

### DIFF
--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -172,8 +172,14 @@ class OnChainHotel implements HotelInterface {
    * @param {HotelOnChainDataInterface} newData
    */
   async setLocalData (newData: HotelOnChainDataInterface): Promise<void> {
-    this.manager = newData.manager;
-    this.dataUri = newData.dataUri;
+    const newManager = await newData.manager;
+    if (newManager) {
+      this.manager = newManager;
+    }
+    const newDataUri = await newData.dataUri;
+    if (newDataUri) {
+      this.dataUri = newDataUri;
+    }
   }
 
   /**

--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -29,7 +29,7 @@ class OnChainHotel implements HotelInterface {
   onChainDataset: RemotelyBackedDataset;
 
   // Representation of data stored on dataUri
-  _dataIndex: StoragePointer;
+  _dataIndex: ?StoragePointer;
 
   /**
    * Create new configured instance.
@@ -139,6 +139,9 @@ class OnChainHotel implements HotelInterface {
       throw new Error(
         'Cannot update hotel: Cannot set dataUri with invalid format'
       );
+    }
+    if (newDataUri !== this._dataUri) {
+      this._dataIndex = null;
     }
 
     this._dataUri = newDataUri;

--- a/test/wt-libs/data-model/on-chain-hotel.spec.js
+++ b/test/wt-libs/data-model/on-chain-hotel.spec.js
@@ -87,6 +87,40 @@ describe('WTLibs.data-model.OnChainHotel', () => {
       assert.equal(storagePointerSpy.callCount, 1);
       storagePointerSpy.restore();
     });
+
+    it('should drop current StoragePointer instance when dataUri changes via setLocalData', async () => {
+      const storagePointerSpy = sinon.spy(StoragePointer, 'createInstance');
+      const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub, 'fake-address');
+      provider.dataUri = 'json://something-new';
+      await provider.dataIndex;
+      assert.equal((await provider.dataIndex).ref, 'json://something-new');
+      assert.equal(storagePointerSpy.callCount, 1);
+      await provider.dataIndex;
+      assert.equal(storagePointerSpy.callCount, 1);
+      await provider.setLocalData({
+        dataUri: 'json://something-completely-different',
+      });
+      await provider.dataIndex;
+      assert.equal(storagePointerSpy.callCount, 2);
+      assert.equal((await provider.dataIndex).ref, 'json://something-completely-different');
+      storagePointerSpy.restore();
+    });
+
+    it('should drop current StoragePointer instance when dataUri changes via direct access', async () => {
+      const storagePointerSpy = sinon.spy(StoragePointer, 'createInstance');
+      const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub, 'fake-address');
+      provider.dataUri = 'json://something-new';
+      await provider.dataIndex;
+      assert.equal((await provider.dataIndex).ref, 'json://something-new');
+      assert.equal(storagePointerSpy.callCount, 1);
+      await provider.dataIndex;
+      assert.equal(storagePointerSpy.callCount, 1);
+      provider.dataUri = 'json://something-completely-different';
+      await provider.dataIndex;
+      assert.equal(storagePointerSpy.callCount, 2);
+      assert.equal((await provider.dataIndex).ref, 'json://something-completely-different');
+      storagePointerSpy.restore();
+    });
   });
 
   describe('setLocalData', () => {


### PR DESCRIPTION
Enables reset on StoragePointer - that will allow us to react once an URI is changed to prevent getting stale data.

Also waits for #136 to be able to call reset in `dataUri` setter.