### PR TITLE
fix: Allows dash in off-chain data link schema

### DIFF
--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -135,7 +135,7 @@ class OnChainHotel implements HotelInterface {
         'Cannot update hotel: Cannot set dataUri when it is not provided'
       );
     }
-    if (typeof newDataUri === 'string' && !newDataUri.match(/([a-z]+):\/\//)) {
+    if (typeof newDataUri === 'string' && !newDataUri.match(/([a-z-]+):\/\//)) {
       throw new Error(
         'Cannot update hotel: Cannot set dataUri with invalid format'
       );

--- a/src/storage-pointer.js
+++ b/src/storage-pointer.js
@@ -154,7 +154,7 @@ class StoragePointer {
    * from `json://some-data`, detects `json`.
    */
   _detectSchema (uri: string): ?string {
-    const matchResult = uri.match(/([a-z]+):\/\//i);
+    const matchResult = uri.match(/([a-z-]+):\/\//i);
     return matchResult ? matchResult[1] : null;
   }
 

--- a/test/wt-libs/data-model/on-chain-hotel.spec.js
+++ b/test/wt-libs/data-model/on-chain-hotel.spec.js
@@ -110,7 +110,7 @@ describe('WTLibs.data-model.OnChainHotel', () => {
       }
     });
 
-    it('should never set invalid url', async () => {
+    it('should never set invalid dataUri', async () => {
       try {
         const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub);
         await provider.setLocalData({ dataUri: validUri, manager: validManager });
@@ -120,6 +120,14 @@ describe('WTLibs.data-model.OnChainHotel', () => {
         assert.match(e.message, /cannot update hotel/i);
         assert.match(e.message, /cannot set dataUri with invalid format/i);
       }
+    });
+
+    it('should allow dash in dataUri', async () => {
+      const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub);
+      await provider.setLocalData({ dataUri: validUri, manager: validManager });
+      assert.equal(await provider.dataUri, validUri);
+      await provider.setLocalData({ dataUri: 'bzz-raw://valid-url', manager: validManager });
+      assert.equal(await provider.dataUri, 'bzz-raw://valid-url');
     });
 
     it('should set manager only when not yet deployed', async () => {

--- a/test/wt-libs/storage-pointer.spec.js
+++ b/test/wt-libs/storage-pointer.spec.js
@@ -13,6 +13,11 @@ describe('WTLibs.StoragePointer', () => {
             return new InMemoryAdapter();
           },
         },
+        'bzz-raw': {
+          create: () => {
+            return new InMemoryAdapter();
+          },
+        },
       },
     });
   });
@@ -104,6 +109,13 @@ describe('WTLibs.StoragePointer', () => {
     } catch (e) {
       assert.match(e.message, /unsupported data storage type/i);
     }
+  });
+
+  it('should not panic on schema with a dash in it', async () => {
+    const pointer = StoragePointer.createInstance('bzz-raw://url', ['some', 'fields']);
+    assert.isUndefined(pointer.__adapter);
+    await pointer.contents.some;
+    assert.isDefined(pointer.__adapter);
   });
 
   it('should recursively instantiate another StoragePointer', async () => {


### PR DESCRIPTION
This fixes a now impossible usage of for example `bzz-raw` protocol.