### PR TITLE
feat: Adds a recursive toPlainObject to StoragePointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,22 @@ const libs = WTLibs.createInstance({
 });
 const index = await libs.getWTIndex('0x...');
 const hotel = await index.getHotel('0x...');
+
+// You can get all the off-chain data at once
+// This approach might be a little slow as all off-chain data gets downloaded
+const plainHotel = await hotel.toPlainObject();
+// You get a synced plain javascript object you can traverse in any way you want
+const hotelName2 = plainHotel.descriptionUri.contents.name;
+
+// OR you can be picky but faster
+
+// Accessing off-chain data - the entry point url is actually stored on chain
 const dataIndex = await hotel.dataIndex;
-// Accessing off-chain data - url is actually stored on chain
-const hotelDescriptionUrl = dataIndex.ref;
+const hotelDataIndexUrl = dataIndex.ref;
 // This data is fetched from some off-chain storage
-const hotelDescription = await dataIndex.contents.description;
-const hotelName = await hotelDescription.contents.name;
+const hotelDescriptionDocument = await dataIndex.contents.descriptionUri;
+// This data is fetched from another off-chain document
+const hotelName = await hotelDescriptionDocument.contents.name;
 ```
 
 ## Documentation

--- a/src/data-interfaces.js
+++ b/src/data-interfaces.js
@@ -1,4 +1,11 @@
 // @flow
+
+export interface PlainHotelInterface {
+  address: Promise<?string> | ?string,
+  manager: Promise<?string> | ?string,
+  dataUri: Promise<{ref: string, contents: Object}> | {ref: string, contents: Object}
+}
+
 /**
  * Index file for more data URIs. This is the
  * initial document that blockchain is pointing to.

--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -194,7 +194,8 @@ class OnChainHotel implements HotelInterface {
    * By default, all off-chain data is resolved recurisvely. If you want to
    * limit off-chain data only to a certain subtree, use the resolvedFields
    * parameter that accepts an array of paths in dot notation (`father.son.child`).
-   * Every last piece of every path will be resolved recursively as well.
+   * Every last piece of every path will be resolved recursively as well. An empty
+   * list means no fields will be resolved.
    *
    * Properties that represent an actual separate document have a format of
    * ```

--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -1,5 +1,6 @@
 // @flow
 import type { TransactionOptionsInterface, WalletInterface, HotelInterface, HotelOnChainDataInterface } from '../interfaces';
+import type { PlainHotelInterface } from '../data-interfaces';
 import Utils from '../utils';
 import Contracts from '../contracts';
 import RemotelyBackedDataset from '../remotely-backed-dataset';
@@ -187,18 +188,35 @@ class OnChainHotel implements HotelInterface {
   }
 
   /**
-   * Helper method that returns a plain object only
-   * with properties with data.
+   * Helper method that transforms the whole hotel into a sync simple
+   * JavaScript object only with data properties.
    *
-   * It is not recursive for now, i. e. all off-chain data
-   * has to be accessed separately. Subject to change.
+   * By default, all off-chain data is resolved recurisvely. If you want to
+   * limit off-chain data only to a certain subtree, use the resolvedFields
+   * parameter that accepts an array of paths in dot notation (`father.son.child`).
+   * Every last piece of every path will be resolved recursively as well.
+   *
+   * Properties that represent an actual separate document have a format of
+   * ```
+   * {
+   *   'ref': 'schema://original-url',
+   *   'contents': {
+   *     'actual': 'data'
+   *   }
+   * }
+   * ```
+   *
+   * @param {resolvedFields} List of fields to be resolved from off chain data, in dot notation.
    */
-  async toPlainObject (): Promise<HotelOnChainDataInterface> {
-    return {
+  async toPlainObject (resolvedFields: ?Array<string>): Promise<PlainHotelInterface> {
+    const dataIndex = (await this.dataIndex);
+    const offChainData = await dataIndex.toPlainObject(resolvedFields);
+    let result = {
       manager: await this.manager,
-      dataUri: await this.dataUri,
       address: this.address,
+      dataUri: offChainData,
     };
+    return result;
   }
 
   async __getContractInstance (): Promise<Object> {

--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -191,7 +191,7 @@ class OnChainHotel implements HotelInterface {
    * Helper method that transforms the whole hotel into a sync simple
    * JavaScript object only with data properties.
    *
-   * By default, all off-chain data is resolved recurisvely. If you want to
+   * By default, all off-chain data is resolved recursively. If you want to
    * limit off-chain data only to a certain subtree, use the resolvedFields
    * parameter that accepts an array of paths in dot notation (`father.son.child`).
    * Every last piece of every path will be resolved recursively as well. An empty
@@ -208,6 +208,7 @@ class OnChainHotel implements HotelInterface {
    * ```
    *
    * @param {resolvedFields} List of fields to be resolved from off chain data, in dot notation.
+   * If an empty array is provided, no resolving is done. If the argument is missing, all fields are resolved.
    */
   async toPlainObject (resolvedFields: ?Array<string>): Promise<PlainHotelInterface> {
     const dataIndex = (await this.dataIndex);

--- a/src/storage-pointer.js
+++ b/src/storage-pointer.js
@@ -210,6 +210,82 @@ class StoragePointer {
     }
     return this.__downloading;
   }
+
+  /**
+   * Recursively transforms the off chain stored document to a sync plain
+   * javascript object. By default, traverses the whole document tree.
+   *
+   * You can limit which branches will get downloaded by providing a `resolvedFields`
+   * argument which acccepts a list of paths in dot notation (`father.son.child`).
+   * Every child will then get resolved recursively.
+   *
+   * If you don't want some paths to get downloaded, just provide at least one sibling
+   * field on that level which is not a `StoragePointer`.
+   *
+   * Data always gets downloaded if this method is called.
+   *
+   * The resulting structure mimicks the original `StoragePointer` data structure:
+   *
+   * ```
+   * {
+   *   'ref': 'schema://url',
+   *   'contents': {
+   *     'field': 'value',
+   *     'storagePointer': {
+   *       'ref': 'schema://originalUri',
+   *       'contents': {
+   *          'field': 'value'
+   *       }
+   *     },
+   *     'unresolvedStoragePointer': 'schema://unresolved-url'
+   *   }
+   * }
+   * ```
+   *
+   *  @param {resolvedFields} list of fields that limit the resulting dataset in dot notation (`father.child.son`)
+   */
+  async toPlainObject (resolvedFields: ?Array<string>): Promise<{ref: string, contents: Object}> {
+    resolvedFields = resolvedFields || [];
+    // Download data
+    await this._downloadFromStorage();
+    const result = {};
+    let currentFieldDef = {};
+    // Prepare subtrees that will possibly be resolved later by splitting the dot notation.
+    for (let field of resolvedFields) {
+      let currentLevelName, remainingPath;
+      if (field.indexOf('.') === -1) {
+        currentLevelName = field;
+      } else {
+        currentLevelName = field.substring(0, field.indexOf('.'));
+        remainingPath = field.substring(field.indexOf('.') + 1);
+      }
+
+      if (!currentFieldDef[currentLevelName]) {
+        currentFieldDef[currentLevelName] = [];
+      }
+      if (remainingPath) {
+        currentFieldDef[currentLevelName].push(remainingPath);
+      }
+    }
+    // Put everything together
+    for (let field of this.__fields) {
+      if (this.__storagePointers[field.name]) {
+        // Storage pointer that the user wants to get resolved - call again for a subtree
+        // OR resolve the whole subrtree if no special field is requested
+        if (Object.keys(currentFieldDef).length === 0 || currentFieldDef[field.name]) {
+          result[field.name] = await (await this.contents[field.name]).toPlainObject(currentFieldDef[field.name]);
+        } else { // Unresolved storage pointer, return a URI
+          result[field.name] = this.__storagePointers[field.name].ref;
+        }
+      } else {
+        result[field.name] = await this.contents[field.name];
+      }
+    }
+    return {
+      ref: this.ref,
+      contents: result,
+    };
+  }
 }
 
 export default StoragePointer;

--- a/src/storage-pointer.js
+++ b/src/storage-pointer.js
@@ -220,7 +220,8 @@ class StoragePointer {
    * Every child will then get resolved recursively.
    *
    * If you don't want some paths to get downloaded, just provide at least one sibling
-   * field on that level which is not a `StoragePointer`.
+   * field on that level which is not a `StoragePointer`. An empty list means no fields
+   * will be resolved.
    *
    * Data always gets downloaded if this method is called.
    *
@@ -242,14 +243,15 @@ class StoragePointer {
    * }
    * ```
    *
-   *  @param {resolvedFields} list of fields that limit the resulting dataset in dot notation (`father.child.son`)
+   *  @param {resolvedFields} list of fields that limit the resulting dataset in dot notation (`father.child.son`).
+   *  If an empty array is provided, no resolving is done. If the argument is missing, all fields are resolved.
    */
   async toPlainObject (resolvedFields: ?Array<string>): Promise<{ref: string, contents: Object}> {
     // Download data
     await this._downloadFromStorage();
     let result = {};
-    let currentFieldDef = {};
     // Prepare subtrees that will possibly be resolved later by splitting the dot notation.
+    let currentFieldDef = {};
     if (resolvedFields) {
       for (let field of resolvedFields) {
         let currentLevelName, remainingPath;
@@ -274,7 +276,7 @@ class StoragePointer {
     for (let field of this.__fields) {
       if (this.__storagePointers[field.name]) {
         // Storage pointer that the user wants to get resolved - call again for a subtree
-        // OR resolve the whole subrtree if no special field is requested
+        // OR resolve the whole subtree if no special fields are requested
         if (!resolvedFields || currentFieldDef.hasOwnProperty(field.name)) {
           result[field.name] = await (await this.contents[field.name]).toPlainObject(currentFieldDef[field.name]);
         } else { // Unresolved storage pointer, return a URI

--- a/test/usage.spec.js
+++ b/test/usage.spec.js
@@ -160,8 +160,11 @@ describe('WTLibs usage', () => {
       const plainHotel = await hotel.toPlainObject();
       assert.isUndefined(plainHotel.toPlainObject);
       assert.equal(plainHotel.address, await hotel.address);
-      assert.equal(plainHotel.dataUri, await hotel.dataUri);
       assert.equal(plainHotel.manager, await hotel.manager);
+      assert.isDefined(plainHotel.dataUri.contents.descriptionUri);
+      assert.isDefined(plainHotel.dataUri.contents.descriptionUri.contents);
+      assert.isDefined(plainHotel.dataUri.contents.descriptionUri.contents.location);
+      assert.equal(plainHotel.dataUri.contents.descriptionUri.contents.name, 'First hotel');
     });
 
     it('should throw if no hotel is found on given address', async () => {
@@ -246,7 +249,9 @@ describe('WTLibs usage', () => {
         assert.isDefined((await hotel.dataIndex).ref);
         const plainHotel = await hotel.toPlainObject();
         assert.equal(plainHotel.address, await hotel.address);
-        assert.equal(plainHotel.dataUri, await hotel.dataUri);
+        assert.equal(plainHotel.manager, await hotel.manager);
+        assert.isDefined(plainHotel.dataUri.ref);
+        assert.isDefined(plainHotel.dataUri.contents);
       }
     });
 

--- a/test/utils/data/off-chain-data.json
+++ b/test/utils/data/off-chain-data.json
@@ -3,7 +3,7 @@
     "descriptionUri": "json://descriptionone"
   },
   "urltwo": {
-    "descriptionUri": "json:descriptiontwo"
+    "descriptionUri": "json://descriptiontwo"
   },
   "descriptionone": {
     "name": "First hotel",

--- a/test/wt-libs/data-model/on-chain-hotel.spec.js
+++ b/test/wt-libs/data-model/on-chain-hotel.spec.js
@@ -188,10 +188,23 @@ describe('WTLibs.data-model.OnChainHotel', () => {
     it('should return a plain JS object', async () => {
       const provider = await OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub);
       await provider.setLocalData({ dataUri: validUri, manager: validManager });
+      // initialize dataIndex so we're able to mock it later
+      await provider.dataIndex;
+      sinon.stub(provider._dataIndex, 'toPlainObject').resolves({
+        ref: validUri,
+        contents: {
+          descriptionUri: {
+            ref: validUri,
+            contents: {},
+          },
+        },
+      });
       const plainHotel = await provider.toPlainObject();
-      assert.equal(plainHotel.dataUri, validUri);
       assert.equal(plainHotel.manager, validManager);
       assert.isUndefined(plainHotel.toPlainObject);
+      assert.equal(plainHotel.dataUri.ref, validUri);
+      assert.isDefined(plainHotel.dataUri.contents);
+      assert.isDefined(plainHotel.dataUri.contents.descriptionUri);
     });
   });
 

--- a/test/wt-libs/storage-pointer.spec.js
+++ b/test/wt-libs/storage-pointer.spec.js
@@ -367,5 +367,13 @@ describe('WTLibs.StoragePointer', () => {
       assert.equal(pojo.contents.eight.contents.five.contents.below.contents.below, 'cows');
       assert.equal(pojo.contents.eight.contents.five.contents.below.contents.above, 'sheep');
     });
+
+    it('should allow the user to not resolve any field', async () => {
+      const pojo = await pointer.toPlainObject([]);
+      assert.equal(pojo.contents.six, 'horses');
+      assert.equal(pojo.contents.seven, 'cats');
+      assert.equal(pojo.contents.eight, `json://${hashLevelOne}`);
+      assert.equal(pojo.contents.nine, `json://${hashLevelTwo}`);
+    });
   });
 });

--- a/test/wt-libs/storage-pointer.spec.js
+++ b/test/wt-libs/storage-pointer.spec.js
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 import StoragePointer from '../../src/storage-pointer';
 import OffChainDataClient from '../../src/off-chain-data-client';
-import { adapter as InMemoryAdapter } from '@windingtree/off-chain-adapter-in-memory';
+import { adapter as InMemoryAdapter, storageInstance } from '@windingtree/off-chain-adapter-in-memory';
 
 describe('WTLibs.StoragePointer', () => {
   beforeEach(() => {
@@ -26,147 +26,118 @@ describe('WTLibs.StoragePointer', () => {
     OffChainDataClient.__reset();
   });
 
-  it('should normalize fields option', () => {
-    const pointer = StoragePointer.createInstance('json://url', ['some', 'fields', { name: 'field' }]);
-    assert.equal(pointer.__fields.length, 3);
-    assert.isDefined(pointer.__fields[0].name);
-    assert.isDefined(pointer.__fields[1].name);
-    assert.isDefined(pointer.__fields[2].name);
-    assert.equal(pointer.__fields[0].name, 'some');
-    assert.equal(pointer.__fields[1].name, 'fields');
-    assert.equal(pointer.__fields[2].name, 'field');
+  describe('initialization', () => {
+    it('should normalize fields option', () => {
+      const pointer = StoragePointer.createInstance('json://url', ['some', 'fields', { name: 'field' }]);
+      assert.equal(pointer.__fields.length, 3);
+      assert.isDefined(pointer.__fields[0].name);
+      assert.isDefined(pointer.__fields[1].name);
+      assert.isDefined(pointer.__fields[2].name);
+      assert.equal(pointer.__fields[0].name, 'some');
+      assert.equal(pointer.__fields[1].name, 'fields');
+      assert.equal(pointer.__fields[2].name, 'field');
+    });
+
+    it('should not panic on empty fields list', () => {
+      try {
+        StoragePointer.createInstance('json://url');
+      } catch (e) {
+        throw new Error(`should have never been called ${e.message}`);
+      }
+    });
+
+    it('should throw on an empty uri', () => {
+      try {
+        StoragePointer.createInstance('');
+        throw new Error('should have never been called');
+      } catch (e) {
+        assert.match(e.message, /without uri/i);
+      }
+
+      try {
+        StoragePointer.createInstance();
+        throw new Error('should have never been called');
+      } catch (e) {
+        assert.match(e.message, /without uri/i);
+      }
+    });
+
+    it('should properly set ref and contents', () => {
+      const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
+      assert.equal(pointer.ref, 'json://url');
+      assert.isDefined(pointer.contents);
+    });
+
+    it('should initialize data getters', () => {
+      const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
+      assert.equal(pointer.ref, 'json://url');
+      assert.isDefined(pointer.contents.some);
+      assert.isDefined(pointer.contents.fields);
+    });
+
+    it('should throw if StoragePointer cannot be set up due to bad uri format', async () => {
+      try {
+        const pointer = StoragePointer.createInstance('jsonxxurl', [{
+          name: 'sp',
+          isStoragePointer: true,
+          fields: ['some', 'fields'],
+        }]);
+        await pointer.contents.sp;
+        throw new Error('should have never been called');
+      } catch (e) {
+        assert.match(e.message, /unsupported data storage type/i);
+      }
+    });
   });
 
-  it('should not panic on empty fields list', () => {
-    try {
-      StoragePointer.createInstance('json://url');
-    } catch (e) {
-      throw new Error(`should have never been called ${e.message}`);
-    }
-  });
-
-  it('should throw on an empty uri', () => {
-    try {
-      StoragePointer.createInstance('');
-      throw new Error('should have never been called');
-    } catch (e) {
-      assert.match(e.message, /without uri/i);
-    }
-
-    try {
-      StoragePointer.createInstance();
-      throw new Error('should have never been called');
-    } catch (e) {
-      assert.match(e.message, /without uri/i);
-    }
-  });
-
-  it('should properly set ref and contents', () => {
-    const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
-    assert.equal(pointer.ref, 'json://url');
-    assert.isDefined(pointer.contents);
-  });
-
-  it('should initialize data getters', () => {
-    const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
-    assert.equal(pointer.ref, 'json://url');
-    assert.isDefined(pointer.contents.some);
-    assert.isDefined(pointer.contents.fields);
-  });
-
-  it('should not download the data immediately', async () => {
-    const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
-    const dldSpy = sinon.spy(pointer, '_downloadFromStorage');
-    assert.equal(dldSpy.callCount, 0);
-    await pointer.contents.some;
-    assert.equal(dldSpy.callCount, 1);
-    await pointer.contents.fields;
-    assert.equal(dldSpy.callCount, 1);
-  });
-
-  it('should properly instantiate OffChainDataAdapter', async () => {
-    const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
-    assert.isUndefined(pointer.__adapter);
-    await pointer.contents.some;
-    assert.isDefined(pointer.__adapter);
-  });
-
-  it('should reuse OffChainDataAdapter instance', async () => {
-    const getAdapterSpy = sinon.spy(OffChainDataClient, 'getAdapter');
-    const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
-    assert.equal(getAdapterSpy.callCount, 0);
-    await pointer.contents.some;
-    assert.equal(getAdapterSpy.callCount, 1);
-    await pointer._getOffChainDataClient();
-    assert.equal(getAdapterSpy.callCount, 1);
-  });
-
-  it('should throw when an unsupported schema is encountered', async () => {
-    try {
-      const pointer = StoragePointer.createInstance('random://url', ['some', 'fields']);
+  describe('data downloading', () => {
+    it('should not download the data immediately', async () => {
+      const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
+      const dldSpy = sinon.spy(pointer, '_downloadFromStorage');
+      assert.equal(dldSpy.callCount, 0);
       await pointer.contents.some;
-      throw new Error('should have never been called');
-    } catch (e) {
-      assert.match(e.message, /unsupported data storage type/i);
-    }
-  });
-
-  it('should not panic on schema with a dash in it', async () => {
-    const pointer = StoragePointer.createInstance('bzz-raw://url', ['some', 'fields']);
-    assert.isUndefined(pointer.__adapter);
-    await pointer.contents.some;
-    assert.isDefined(pointer.__adapter);
-  });
-
-  it('should recursively instantiate another StoragePointer', async () => {
-    const pointer = StoragePointer.createInstance('json://url', [{
-      name: 'sp',
-      isStoragePointer: true,
-      fields: ['some', 'fields'],
-    }]);
-    sinon.stub(pointer, '_getOffChainDataClient').resolves({
-      download: sinon.stub().returns({
-        'sp': 'json://point',
-      }),
+      assert.equal(dldSpy.callCount, 1);
+      await pointer.contents.fields;
+      assert.equal(dldSpy.callCount, 1);
     });
-    assert.equal(pointer.ref, 'json://url');
-    const recursivePointer = await pointer.contents.sp;
-    assert.equal(recursivePointer.constructor.name, 'StoragePointer');
-    assert.equal(recursivePointer.ref, 'json://point');
-    assert.isDefined(recursivePointer.contents.some);
-    assert.isDefined(recursivePointer.contents.fields);
-  });
 
-  it('should not panic if recursive StoragePointer does not have fields defined', async () => {
-    const pointer = StoragePointer.createInstance('json://url', [{
-      name: 'sp',
-      isStoragePointer: true,
-    }]);
-    sinon.stub(pointer, '_getOffChainDataClient').resolves({
-      download: sinon.stub().returns({
-        'sp': 'json://point',
-      }),
+    it('should properly instantiate OffChainDataAdapter', async () => {
+      const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
+      assert.isUndefined(pointer.__adapter);
+      await pointer.contents.some;
+      assert.isDefined(pointer.__adapter);
     });
-    assert.equal(pointer.ref, 'json://url');
-    await pointer.contents.sp;
+
+    it('should reuse OffChainDataAdapter instance', async () => {
+      const getAdapterSpy = sinon.spy(OffChainDataClient, 'getAdapter');
+      const pointer = StoragePointer.createInstance('json://url', ['some', 'fields']);
+      assert.equal(getAdapterSpy.callCount, 0);
+      await pointer.contents.some;
+      assert.equal(getAdapterSpy.callCount, 1);
+      await pointer._getOffChainDataClient();
+      assert.equal(getAdapterSpy.callCount, 1);
+    });
+
+    it('should throw when an unsupported schema is encountered', async () => {
+      try {
+        const pointer = StoragePointer.createInstance('random://url', ['some', 'fields']);
+        await pointer.contents.some;
+        throw new Error('should have never been called');
+      } catch (e) {
+        assert.match(e.message, /unsupported data storage type/i);
+      }
+    });
+
+    it('should not panic on schema with a dash in it', async () => {
+      const pointer = StoragePointer.createInstance('bzz-raw://url', ['some', 'fields']);
+      assert.isUndefined(pointer.__adapter);
+      await pointer.contents.some;
+      assert.isDefined(pointer.__adapter);
+    });
   });
 
-  it('should throw if recursive StoragePointer cannot be set up due to null pointer value', async () => {
-    try {
-      const pointer = StoragePointer.createInstance('json://url', [{
-        name: 'sp',
-        isStoragePointer: true,
-        fields: ['some', 'fields'],
-      }]);
-      await pointer.contents.sp;
-      throw new Error('should have never been called');
-    } catch (e) {
-      assert.match(e.message, /which does not appear to be a valid reference/i);
-    }
-  });
-
-  it('should throw if recursive StoragePointer cannot be set up due to a malformed pointer value', async () => {
-    try {
+  describe('recursion', () => {
+    it('should recursively instantiate another StoragePointer', async () => {
       const pointer = StoragePointer.createInstance('json://url', [{
         name: 'sp',
         isStoragePointer: true,
@@ -174,49 +145,84 @@ describe('WTLibs.StoragePointer', () => {
       }]);
       sinon.stub(pointer, '_getOffChainDataClient').resolves({
         download: sinon.stub().returns({
-          'sp': { some: 'field' },
-        }),
-      });
-      await pointer.contents.sp;
-      throw new Error('should have never been called');
-    } catch (e) {
-      assert.match(e.message, /which does not appear to be a valid reference/i);
-    }
-  });
-
-  it('should throw if recursive StoragePointer cannot be set up due to bad schema', async () => {
-    try {
-      const pointer = StoragePointer.createInstance('json://url', [{
-        name: 'sp',
-        isStoragePointer: true,
-        fields: ['some', 'fields'],
-      }]);
-      sinon.stub(pointer, '_getOffChainDataClient').resolves({
-        download: sinon.stub().returns({
-          'sp': 'random://point',
+          'sp': 'json://point',
         }),
       });
       assert.equal(pointer.ref, 'json://url');
-      const childPointer = await pointer.contents.sp;
-      await childPointer.contents.some;
-      throw new Error('should have never been called');
-    } catch (e) {
-      assert.match(e.message, /unsupported data storage type/i);
-    }
-  });
+      const recursivePointer = await pointer.contents.sp;
+      assert.equal(recursivePointer.constructor.name, 'StoragePointer');
+      assert.equal(recursivePointer.ref, 'json://point');
+      assert.isDefined(recursivePointer.contents.some);
+      assert.isDefined(recursivePointer.contents.fields);
+    });
 
-  it('should throw if StoragePointer cannot be set up due to bad uri format', async () => {
-    try {
-      const pointer = StoragePointer.createInstance('jsonxxurl', [{
+    it('should not panic if recursive StoragePointer does not have fields defined', async () => {
+      const pointer = StoragePointer.createInstance('json://url', [{
         name: 'sp',
         isStoragePointer: true,
-        fields: ['some', 'fields'],
       }]);
+      sinon.stub(pointer, '_getOffChainDataClient').resolves({
+        download: sinon.stub().returns({
+          'sp': 'json://point',
+        }),
+      });
+      assert.equal(pointer.ref, 'json://url');
       await pointer.contents.sp;
-      throw new Error('should have never been called');
-    } catch (e) {
-      assert.match(e.message, /unsupported data storage type/i);
-    }
+    });
+
+    it('should throw if recursive StoragePointer cannot be set up due to null pointer value', async () => {
+      try {
+        const pointer = StoragePointer.createInstance('json://url', [{
+          name: 'sp',
+          isStoragePointer: true,
+          fields: ['some', 'fields'],
+        }]);
+        await pointer.contents.sp;
+        throw new Error('should have never been called');
+      } catch (e) {
+        assert.match(e.message, /which does not appear to be a valid reference/i);
+      }
+    });
+
+    it('should throw if recursive StoragePointer cannot be set up due to a malformed pointer value', async () => {
+      try {
+        const pointer = StoragePointer.createInstance('json://url', [{
+          name: 'sp',
+          isStoragePointer: true,
+          fields: ['some', 'fields'],
+        }]);
+        sinon.stub(pointer, '_getOffChainDataClient').resolves({
+          download: sinon.stub().returns({
+            'sp': { some: 'field' },
+          }),
+        });
+        await pointer.contents.sp;
+        throw new Error('should have never been called');
+      } catch (e) {
+        assert.match(e.message, /which does not appear to be a valid reference/i);
+      }
+    });
+
+    it('should throw if recursive StoragePointer cannot be set up due to bad schema', async () => {
+      try {
+        const pointer = StoragePointer.createInstance('json://url', [{
+          name: 'sp',
+          isStoragePointer: true,
+          fields: ['some', 'fields'],
+        }]);
+        sinon.stub(pointer, '_getOffChainDataClient').resolves({
+          download: sinon.stub().returns({
+            'sp': 'random://point',
+          }),
+        });
+        assert.equal(pointer.ref, 'json://url');
+        const childPointer = await pointer.contents.sp;
+        await childPointer.contents.some;
+        throw new Error('should have never been called');
+      } catch (e) {
+        assert.match(e.message, /unsupported data storage type/i);
+      }
+    });
   });
 
   describe('reset()', () => {
@@ -246,6 +252,120 @@ describe('WTLibs.StoragePointer', () => {
       await pointer.reset();
       await pointer.contents.some;
       assert.equal(dldSpy.callCount, 2);
+    });
+  });
+
+  describe('toPlainObject', () => {
+    let pointer, hashLevelZero, hashLevelOne, hashLevelTwo, hashLevelThree;
+    before(() => {
+      hashLevelThree = storageInstance.create({ below: 'cows', above: 'sheep' });
+      hashLevelTwo = storageInstance.create({ one: 'bunny', two: 'frogs', below: `json://${hashLevelThree}` });
+      hashLevelOne = storageInstance.create({ three: 'dogs', four: 'donkeys', five: `json://${hashLevelTwo}` });
+      hashLevelZero = storageInstance.create({ six: 'horses', seven: 'cats', eight: `json://${hashLevelOne}`, nine: `json://${hashLevelTwo}` });
+      pointer = StoragePointer.createInstance(`json://${hashLevelZero}`, [
+        'six', 'seven', {
+          name: 'eight',
+          isStoragePointer: true,
+          fields: [
+            'three', 'four',
+            {
+              name: 'five',
+              isStoragePointer: true,
+              fields: ['one', 'two', {
+                name: 'below',
+                isStoragePointer: true,
+                fields: ['below', 'above'],
+              }],
+            },
+          ],
+        }, {
+          name: 'nine',
+          isStoragePointer: true,
+          fields: ['one', 'two', {
+            name: 'below',
+            isStoragePointer: true,
+            fields: ['below', 'above'],
+          }],
+        },
+      ]);
+    });
+
+    it('should return a complete data tree without arguments', async () => {
+      const pojo = await pointer.toPlainObject();
+      assert.equal(pojo.contents.six, 'horses');
+      assert.equal(pojo.contents.seven, 'cats');
+      assert.equal(pojo.contents.eight.contents.three, 'dogs');
+      assert.equal(pojo.contents.eight.contents.four, 'donkeys');
+      assert.equal(pojo.contents.eight.contents.five.contents.one, 'bunny');
+      assert.equal(pojo.contents.eight.contents.five.contents.two, 'frogs');
+      assert.equal(pojo.contents.eight.contents.five.contents.below.contents.below, 'cows');
+      assert.equal(pojo.contents.eight.contents.five.contents.below.contents.above, 'sheep');
+      assert.equal(pojo.contents.nine.contents.one, 'bunny');
+      assert.equal(pojo.contents.nine.contents.two, 'frogs');
+      assert.equal(pojo.contents.nine.contents.below.contents.below, 'cows');
+      assert.equal(pojo.contents.nine.contents.below.contents.above, 'sheep');
+    });
+
+    it('should limit resolved fields', async () => {
+      const pojo = await pointer.toPlainObject(['eight']);
+      assert.equal(pojo.contents.six, 'horses');
+      assert.equal(pojo.contents.seven, 'cats');
+      assert.isDefined(pojo.contents.eight);
+      assert.equal(pojo.contents.eight.contents.three, 'dogs');
+      assert.equal(pojo.contents.eight.contents.four, 'donkeys');
+      assert.equal(pojo.contents.eight.contents.five.contents.one, 'bunny');
+      assert.equal(pojo.contents.eight.contents.five.contents.two, 'frogs');
+      assert.equal(pojo.contents.eight.contents.five.contents.below.contents.below, 'cows');
+      assert.equal(pojo.contents.eight.contents.five.contents.below.contents.above, 'sheep');
+      assert.equal(pojo.contents.nine, `json://${hashLevelTwo}`);
+    });
+
+    it('should resolve multiple recursive fields', async () => {
+      const pojo = await pointer.toPlainObject(['eight.five.two', 'nine.below.above']);
+      assert.equal(pojo.contents.six, 'horses');
+      assert.equal(pojo.contents.seven, 'cats');
+      assert.isDefined(pojo.contents.eight);
+      assert.equal(pojo.contents.eight.contents.three, 'dogs');
+      assert.equal(pojo.contents.eight.contents.four, 'donkeys');
+      assert.equal(pojo.contents.eight.contents.five.contents.two, 'frogs');
+      assert.equal(pojo.contents.nine.contents.one, 'bunny');
+      assert.equal(pojo.contents.nine.contents.below.contents.above, 'sheep');
+    });
+
+    it('should resolve field on a second level', async () => {
+      const pojo = await pointer.toPlainObject(['eight.four', 'eight.three']);
+      assert.equal(pojo.contents.six, 'horses');
+      assert.equal(pojo.contents.seven, 'cats');
+      assert.isDefined(pojo.contents.eight);
+      assert.equal(pojo.contents.eight.contents.three, 'dogs');
+      assert.equal(pojo.contents.eight.contents.four, 'donkeys');
+      assert.equal(pojo.contents.eight.contents.five, `json://${hashLevelTwo}`);
+    });
+
+    it('should resolve field on a second level when asked for multiple times', async () => {
+      const pojo = await pointer.toPlainObject(['eight.five']);
+      assert.equal(pojo.contents.six, 'horses');
+      assert.equal(pojo.contents.seven, 'cats');
+      assert.isDefined(pojo.contents.eight);
+      assert.equal(pojo.contents.eight.contents.three, 'dogs');
+      assert.equal(pojo.contents.eight.contents.four, 'donkeys');
+      assert.isDefined(pojo.contents.eight.contents.five);
+      assert.equal(pojo.contents.eight.contents.five.contents.one, 'bunny');
+      assert.equal(pojo.contents.eight.contents.five.contents.two, 'frogs');
+      assert.equal(pojo.contents.eight.contents.five.contents.below.contents.below, 'cows');
+      assert.equal(pojo.contents.eight.contents.five.contents.below.contents.above, 'sheep');
+
+      const pojo2 = await pointer.toPlainObject(['eight.five.one']);
+      assert.equal(pojo2.contents.six, 'horses');
+      assert.equal(pojo2.contents.seven, 'cats');
+      assert.isDefined(pojo2.contents.eight);
+      assert.equal(pojo2.contents.eight.contents.three, 'dogs');
+      assert.equal(pojo2.contents.eight.contents.four, 'donkeys');
+      assert.isDefined(pojo2.contents.eight.contents.five);
+      assert.equal(pojo2.contents.eight.contents.five.contents.one, 'bunny');
+      assert.equal(pojo2.contents.eight.contents.five.contents.two, 'frogs');
+      assert.equal(pojo.contents.eight.contents.five.contents.below.contents.below, 'cows');
+      assert.equal(pojo.contents.eight.contents.five.contents.below.contents.above, 'sheep');
     });
   });
 });


### PR DESCRIPTION
Closes #134 

In the end I haven't used a depth attribute, as it can be controlled by the user who has to specify which particular fields she would like to get. If a StoragePointer is encountered on the way, it gets resolved. Nothing that is not explicitlly mentioned is never resolved. No data is silently stripped, so once a StoragePointer is resolved, all of its data is returned.