### PR TITLE
fix: No dataUri can be resolved when accessing dataIndex

### DIFF
--- a/src/data-model/on-chain-hotel.js
+++ b/src/data-model/on-chain-hotel.js
@@ -33,6 +33,7 @@ class OnChainHotel implements HotelInterface {
 
   // Representation of data stored on dataUri
   _dataIndex: ?StoragePointer;
+  _initialized: boolean;
 
   /**
    * Create new configured instance.
@@ -80,6 +81,7 @@ class OnChainHotel implements HotelInterface {
         },
       },
     }, this);
+    this._initialized = true;
     if (this.address) {
       this.onChainDataset.markDeployed();
     }
@@ -123,10 +125,9 @@ class OnChainHotel implements HotelInterface {
   }
 
   get dataUri (): Promise<?string> | ?string {
-    if (!this._dataUri) {
+    if (!this._initialized) {
       return;
     }
-
     return (async () => {
       const dataUri = await this._dataUri;
       return dataUri;
@@ -152,10 +153,9 @@ class OnChainHotel implements HotelInterface {
   }
 
   get manager (): Promise<?string> | ?string {
-    if (!this._manager) {
+    if (!this._initialized) {
       return;
     }
-
     return (async () => {
       const manager = await this._manager;
       return manager;

--- a/src/remotely-backed-dataset.js
+++ b/src/remotely-backed-dataset.js
@@ -41,6 +41,7 @@ class RemotelyBackedDataset {
     this._remoteData = {};
     this._fieldStates = {};
     this._fieldKeys = [];
+    this._syncing = null;
   }
 
   /**
@@ -194,20 +195,25 @@ class RemotelyBackedDataset {
   }
 
   async _syncRemoteData () {
-    try {
-      await this._fetchRemoteData();
-      // Copy over data from remoteData to local data
-      for (let i = 0; i < this._fieldKeys.length; i++) {
-        // Do not update user-modified fields
-        // TODO deal with 3rd party data modificiation on a remote storage
-        if (this._remoteData[this._fieldKeys[i]] !== this._localData[this._fieldKeys[i]] && this._fieldStates[this._fieldKeys[i]] !== 'dirty') {
-          this._localData[this._fieldKeys[i]] = this._remoteData[this._fieldKeys[i]];
-          this._fieldStates[this._fieldKeys[i]] = 'synced';
+    if (!this._syncing) {
+      this._syncing = (async () => {
+        try {
+          await this._fetchRemoteData();
+          // Copy over data from remoteData to local data
+          for (let i = 0; i < this._fieldKeys.length; i++) {
+            // Do not update user-modified fields
+            // TODO deal with 3rd party data modificiation on a remote storage
+            if (this._remoteData[this._fieldKeys[i]] !== this._localData[this._fieldKeys[i]] && this._fieldStates[this._fieldKeys[i]] !== 'dirty') {
+              this._localData[this._fieldKeys[i]] = this._remoteData[this._fieldKeys[i]];
+              this._fieldStates[this._fieldKeys[i]] = 'synced';
+            }
+          }
+        } catch (err) {
+          throw new RemoteDataReadError('Cannot sync remote data: ' + err.message);
         }
-      }
-    } catch (err) {
-      throw new RemoteDataReadError('Cannot sync remote data: ' + err.message);
+      })();
     }
+    return this._syncing;
   }
 
   // https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript-jquery

--- a/src/remotely-backed-dataset.js
+++ b/src/remotely-backed-dataset.js
@@ -141,7 +141,9 @@ class RemotelyBackedDataset {
     // This is a totally new instance
     // TODO maybe don't init all at once, it might be expensive
     if (this.isDeployed() && this._fieldStates[property] === 'unsynced') {
-      await this._syncRemoteData();
+      return this._syncRemoteData().then(() => {
+        return this._localData[property];
+      });
     }
 
     return this._localData[property];

--- a/test/wt-libs/data-model/on-chain-hotel.spec.js
+++ b/test/wt-libs/data-model/on-chain-hotel.spec.js
@@ -259,16 +259,14 @@ describe('WTLibs.data-model.OnChainHotel', () => {
       const provider = OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub, 'fake-address');
       assert.equal(urlStub().call.callCount, 0);
       await provider.dataUri;
-      // The getter of url calls twice this._url
-      assert.equal(urlStub().call.callCount, 2);
+      assert.equal(urlStub().call.callCount, 1);
     });
 
     it('should setup remoteGetter for manager', async () => {
       const provider = OnChainHotel.createInstance(utilsStub, contractsStub, indexContractStub, 'fake-address');
       assert.equal(managerStub().call.callCount, 0);
       await provider.manager;
-      // The getter of manager calls twice this._manager
-      assert.equal(managerStub().call.callCount, 2);
+      assert.equal(managerStub().call.callCount, 1);
     });
   });
 


### PR DESCRIPTION
This PR  actually deals with [this bug](https://trello.com/c/KwaglvqD/92-wt-js-libs-might-crash-during-data-access-missing-on-chain-data). This occurs also when accessing an older version of smart contracts.