### PR TITLE
feat: Caching WTIndex instances

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,4 +15,5 @@ assets
 .solcover.js
 .eslintrc.js
 .travis.yml
+.babelrc
 truffle-config.js

--- a/src/data-interfaces.js
+++ b/src/data-interfaces.js
@@ -33,7 +33,6 @@ export interface HotelDescriptionInterface {
 }
 
 export interface RoomTypeInterface {
-  id: Promise<string> | string,
   name: Promise<string> | string,
   description: Promise<string> | string,
   totalQuantity: Promise<number> | number,

--- a/src/data-model/index.js
+++ b/src/data-model/index.js
@@ -33,6 +33,7 @@ class DataModel implements DataModelInterface {
   web3Instance: Web3;
   web3Utils: Utils;
   web3Contracts: Contracts;
+  _wtIndexCache: {[address: string]: WTIndexDataProvider};
 
   /**
    * Creates a configured DataModel instance.
@@ -51,13 +52,17 @@ class DataModel implements DataModelInterface {
     this.web3Instance = new Web3(this.options.provider);
     this.web3Utils = Utils.createInstance(this.options.gasCoefficient, this.web3Instance);
     this.web3Contracts = Contracts.createInstance(this.web3Instance);
+    this._wtIndexCache = {};
   }
 
   /**
    * Returns an Ethereum backed Winding Tree index.
    */
   getWindingTreeIndex (address: string): WTIndexDataProvider {
-    return WTIndexDataProvider.createInstance(address, this.web3Utils, this.web3Contracts);
+    if (!this._wtIndexCache[address]) {
+      this._wtIndexCache[address] = WTIndexDataProvider.createInstance(address, this.web3Utils, this.web3Contracts);
+    }
+    return this._wtIndexCache[address];
   }
 
   /**

--- a/test/wt-libs/data-model/index.spec.js
+++ b/test/wt-libs/data-model/index.spec.js
@@ -1,0 +1,20 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import Web3UriDataModel from '../../../src/data-model/';
+import WTIndexDataProvider from '../../../src/data-model/wt-index';
+import testedDataModel from '../../utils/data-model-definition';
+
+describe('WTLibs.data-model', () => {
+  it('should cache WTIndex instances', () => {
+    const dataModel = Web3UriDataModel.createInstance(testedDataModel.withDataSource().dataModelOptions);
+    const createInstanceSpy = sinon.spy(WTIndexDataProvider, 'createInstance');
+    assert.equal(createInstanceSpy.callCount, 0);
+    dataModel.getWindingTreeIndex('address1');
+    assert.equal(createInstanceSpy.callCount, 1);
+    dataModel.getWindingTreeIndex('address1');
+    assert.equal(createInstanceSpy.callCount, 1);
+    dataModel.getWindingTreeIndex('address2');
+    assert.equal(createInstanceSpy.callCount, 2);
+    createInstanceSpy.restore();
+  });
+});


### PR DESCRIPTION
Closes #165.

Also incorporates a small change resulting from windingtree/wiki#39 (it's just an interface, so no actual change to functionality).

Also drops babelrc from the NPM packages as https://github.com/MaiaVictor/swarm-js/issues/21 makes a valid point. I could do it in another PR, but I like to live dangerously.